### PR TITLE
Fixed `mkdocs-note init` command to correctly use tree-based asset directory structure

### DIFF
--- a/CHANGELAOG.md
+++ b/CHANGELAOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [Unreleased]
+## 1.1.1 - 2025-10-06
 
 ### Changed
 

--- a/CHANGELAOG.md
+++ b/CHANGELAOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.2 - 2025-10-06
+
+### Fixed
+
+- Fixed `mkdocs-note init` command to correctly use tree-based asset directory structure
+  
+  - Previously, the init command was creating asset directories in a flat structure (e.g., `assets/note-name/`) instead of mirroring the notes directory hierarchy
+  
+  - Now uses `get_note_relative_path()` function consistently across all components to ensure proper tree-based structure
+  
+  - Updated `_check_compliance()` method to correctly validate tree-based structures with `.assets` suffix on first-level subdirectories
+  
+  - This ensures that `mkdocs-note init` and `mkdocs-note new` create consistent directory structures
+
 
 ## 1.1.1 - 2025-10-06
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-note"
-version = "1.1.1"
+version = "1.1.2"
 description = "A MkDocs plugin to add note boxes to your documentation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="mkdocs-note",
-    version="1.1.1",
+    version="1.1.2",
     author="virtualguard101",
     author_email="virtualguard101@gmail.com",
     description="A MkDocs plugin to add note boxes to your documentation.",

--- a/uv.lock
+++ b/uv.lock
@@ -263,7 +263,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-note"
-version = "1.1.1"
+version = "1.1.2"
 source = { virtual = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
  - Previously, the init command was creating asset directories in a flat structure (e.g., `assets/note-name/`) instead of mirroring the notes directory hierarchy
  
  - Now uses `get_note_relative_path()` function consistently across all components to ensure proper tree-based structure
  
  - Updated `_check_compliance()` method to correctly validate tree-based structures with `.assets` suffix on first-level subdirectories
  
  - This ensures that `mkdocs-note init` and `mkdocs-note new` create consistent directory structures
