### PR TITLE
chore: modified 'publish' field as 'false' by default in note template

### DIFF
--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -12,6 +12,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.1.2 - 2026-04-08
+
+### Changed
+
+- Modified `publish` field in note frontmatter as `false` by default, to prevent notes from being published before they are ready.
+
 ## 3.1.1 - 2026-02-08
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-note"
-version = "3.1.1"
+version = "3.1.2"
 description = "A MkDocs plugin to add note boxes to your documentation."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/mkdocs_note/utils/cli/commands.py
+++ b/src/mkdocs_note/utils/cli/commands.py
@@ -30,7 +30,7 @@ class NewCommand:
 date: {datetime.now().strftime(self.timestamp_format)}
 title: {file_path.stem.replace("-", " ").replace("_", " ").title()}
 permalink: {permalink}
-publish: true
+publish: false
 tags:
   - 
 ---

--- a/uv.lock
+++ b/uv.lock
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-note"
-version = "3.1.0"
+version = "3.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
Modified `publish` field in note frontmatter as `false` by default, to prevent notes from being published before they are ready.
