### PR TITLE
feat: add notion auto sync command line interface

### DIFF
--- a/.cursor/plans/notion_sync_adaptation_127cae36.plan.md
+++ b/.cursor/plans/notion_sync_adaptation_127cae36.plan.md
@@ -1,0 +1,146 @@
+---
+name: Notion Sync Adaptation
+overview: 将 notion_sync.py 适配为 mkdocs-note notion-sync / ns CLI；共享 meta/树 + Notion 三层（convert/client/sync）；配置以 mkdocs.yml 为主；Cursor MCP token 为可选开发者开关；参考文件暂留。
+todos:
+  - id: shared-reuse
+    content: 扩展 meta（path 级 frontmatter/tags）与目录→层级树工具，供 Notion 与插件共用
+    status: completed
+  - id: config-cli-skeleton
+    content: config.py notion_sync（含 MCP 开关与警告开关）；cli.py notion-sync + ns；utils/notion 三层骨架
+    status: completed
+  - id: port-notion-core
+    content: 迁入 convert.py / client.py / sync.py（nav、git、state、token 在 sync）；配置驱动；PyYAML
+    status: completed
+  - id: wire-cli-config
+    content: CLI 读 mkdocs.yml；MCP 受控警告；dry-run 打通
+    status: completed
+  - id: tests-docs
+    content: 单测；用户手册不提 MCP；开发者/API 可提；changelog/architecture；参考文件暂留（6B）
+    status: completed
+isProject: false
+---
+
+# Notion 同步适配到 mkdocs-note
+
+## 已确认决策（全部）
+
+| # | 决策 |
+|---|------|
+| 1 | **仅 CLI**：`mkdocs-note notion-sync` + 别名 **`ns`**；不挂 build 钩子 |
+| 2 | 页面树：**优先 `.nav.yml`**；缺失则 **`notes_root` 层级扫描**；回退时 WARNING 建议 awesome-nav |
+| 3 | 配置主要在 **`mkdocs.yml` → `notion_sync:`**；token 走 env / 本地文件（及可选 MCP） |
+| 4 | Cursor MCP 读 token：**默认关**，`allow_cursor_mcp_token` 启用；启用成功取 token 时 WARNING（可用 `silence_mcp_token_warning` 关闭）；**用户手册不写**，开发者/API 可写 |
+| 5 | **A′**：共享内核（meta + 目录树）+ Notion 三层 **`convert` / `client` / `sync`** |
+| 6 | 根目录 `notion_sync.py` / `NOTION.md` **暂留对照**，文档合入后再删 |
+| 复用 | 扩展现有 `meta` / 树构建，禁止平行再实现 frontmatter/扫描 |
+
+---
+
+## 目标结构（A′）
+
+```mermaid
+flowchart LR
+  CLI["cli.py notion-sync / ns"] --> Sync["utils/notion/sync.py"]
+  Sync --> Convert["utils/notion/convert.py"]
+  Sync --> Client["utils/notion/client.py"]
+  Sync --> Meta["utils/meta.py"]
+  Sync --> Tree["utils/tree.py 或 scanner 扩展"]
+  Config["config.py notion_sync"] --> Sync
+```
+
+### 共享内核
+
+- **[`utils/meta.py`](src/mkdocs_note/utils/meta.py)**：增加面向 `Path`/`str` 的 frontmatter 解析与 `extract_tags`；保留现有 MkDocs `File` API；Notion convert 调用共享实现。
+- **目录→层级树**（新建 `utils/tree.py` 或扩展 scanner）：产出与 `.nav.yml` 解析相同形状的节点（目录→section，`.md`/`.ipynb`→页，跳过 `index.md`）；供 Notion 回退与未来 CLI 复用。
+
+### Notion 包（三层）
+
+| 文件 | 职责 |
+|------|------|
+| [`utils/notion/convert.py`](src/mkdocs_note/utils/notion/convert.py) | Markdown / ipynb → Notion Enhanced Markdown（纯转换，无网络） |
+| [`utils/notion/client.py`](src/mkdocs_note/utils/notion/client.py) | Notion HTTP：建页、markdown PATCH、tags schema、图片 upload/block、重试 |
+| [`utils/notion/sync.py`](src/mkdocs_note/utils/notion/sync.py) | 编排：token、`.nav.yml`/树回退、git diff、state、`ensure_section`、`sync_one_page`、`run_sync` |
+| [`utils/notion/__init__.py`](src/mkdocs_note/utils/notion/__init__.py) | 导出 `run_sync` |
+
+日后若 convert/client 膨胀或出现第二种变更检测，再从 `sync.py` 拆出 `nav` / `git_diff`。
+
+代码风格：tab 缩进、type hints、docstring；YAML 用 PyYAML。
+
+---
+
+## 配置
+
+```yaml
+plugins:
+  - mkdocs-note:
+      notes_root: docs
+      notion_sync:
+        docs_dir: docs
+        nav_file: docs/.nav.yml
+        database_id: ""
+        data_source_id: ""
+        title_property: "页面"
+        tags_property: "标签"
+        site_url: ""
+        state_path: ".notion_sync_state.json"
+        delay: 0.35
+        allow_cursor_mcp_token: false
+        silence_mcp_token_warning: false
+```
+
+- `database_id` / `data_source_id` / `site_url` **无硬编码默认**；可被 `NOTION_WIKI_DATABASE`、`NOTION_WIKI_DATA_SOURCE`、`NOTION_STATE_PATH` 等环境变量覆盖。
+- CLI flag（`--full`、`--base`、`--paths`、`--section`、`--dry-run`、`--rebuild-state`、`--no-images`、`--token` 等）覆盖配置。
+
+### MCP token 行为
+
+1. 仅 `allow_cursor_mcp_token: true` 时解析链包含 `~/.cursor/mcp.json`。
+2. 从 MCP 取到 token 时 WARNING：不建议使用，除非开发者成员或有特殊需求；并提示可用 `silence_mcp_token_warning: true` 关闭。
+3. usage 文档不提；contributing / references 可提。
+
+Token 链：`--token` → env → `.env` / `.notion_token` → `~/.config/notion/token` →（可选）Cursor mcp.json。
+
+---
+
+## CLI
+
+```bash
+mkdocs-note notion-sync [...]
+mkdocs-note ns [...]
+```
+
+从项目根加载 `mkdocs.yml` 插件段；组装参数后调用 `run_sync`。
+
+---
+
+## 行为保留
+
+git 增量、`--full`、本地删除不 prune Notion、`index.md` 不同步、标签 multi_select + schema 合并、本地图占位后 Blocks 上传、429 重试与 delay。
+
+适配：路径与 Wiki ID 配置驱动；页面树双源；复用 meta/树。
+
+---
+
+## 测试与文档
+
+- 单测：`meta` 共用 API；树构建（yml + notes_root）；`convert`；必要时 mock client 烟测。
+- 文档：`docs/usage/notion-sync.md` + 更新 cli/config；architecture/changelog（建议 **3.2.0**）；`.nav.yml` 挂页。
+- 用户手册不提 MCP；开发者/API 提及。
+- 根目录参考文件按 6B **暂留**。
+
+---
+
+## 实施顺序
+
+1. 扩展共享 `meta` + 目录层级树工具  
+2. `notion_sync` 配置项 + CLI `notion-sync`/`ns` + `utils/notion` 三层骨架  
+3. 迁入 convert → client → sync，打通 dry-run  
+4. mkdocs.yml 加载、MCP 开关与警告、对照原脚本行为  
+5. 测试 + 分层文档 + architecture/changelog；参考文件暂留  
+
+---
+
+## 风险与边界
+
+- rebuild-state 同父同标题误匹配、tabs 近似等取舍原样保留并写入文档。  
+- 本次仅让 notion-sync 正确读 `mkdocs.yml`，不顺便改造 `new`/`move` 的配置加载。  
+- 全量 + 大量本地图仍慢；文档强调默认增量。

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ site/
 
 # Secret files
 test_publish.sh
+.notion_token
+.notion_sync_state.json
+.env

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -10,6 +10,7 @@ nav:
     - Command Line Interface: usage/cli.md
     - Asset Management: usage/asset-manager.md
     - Network Graph Visualization: usage/network-graph.md
+    - Notion Sync: usage/notion-sync.md
     - Configuration Options: usage/config.md
 
   - Contributing Guide:

--- a/docs/about/changelog.md
+++ b/docs/about/changelog.md
@@ -12,6 +12,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.2.0 - 2026-08-03
+
+### Added
+
+- Notion wiki sync via CLI: `mkdocs-note notion-sync` / `ns` (git-diff incremental by default).
+
+- Plugin config `notion_sync` for docs/nav paths, wiki IDs, tags/title properties, and delay.
+
+- Shared helpers: path-level frontmatter / tags in `utils.meta`, hierarchical page tree in `utils.tree`.
+
+- Notion package: `utils.notion.convert`, `utils.notion.client`, `utils.notion.sync`.
+
+- User guide: [Notion Sync](../usage/notion-sync.md).
+
+### Changed
+
+- Documentation for CLI and configuration options updated for Notion sync.
+
 ## 3.1.2 - 2026-04-08
 
 ### Changed

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -110,22 +110,21 @@ mkdocs-note/
 │   │   ├── graph.js
 │   │   └── graph.css
 │   │
-│   └── utils/                   # Minimal utility modules
+│   └── utils/                   # Utility modules
 │       ├── __init__.py
-│       ├── meta.py              # Metadata extraction (title, date, frontmatter validation)
-│       ├── scanner.py           # File scanning
+│       ├── meta.py              # Metadata / frontmatter (File + path APIs)
+│       ├── scanner.py           # File scanning (MkDocs Files)
+│       ├── tree.py              # Page tree from .nav.yml or directory hierarchy
+│       ├── notion/              # Notion sync (CLI)
+│       │   ├── convert.py       # Markdown → Notion Enhanced Markdown
+│       │   ├── client.py        # Notion HTTP API
+│       │   └── sync.py          # Orchestration (token, git diff, state, run_sync)
 │       └── cli/                 # CLI command implementations
 │           ├── __init__.py
 │           ├── commands.py      # NewCommand, RemoveCommand, MoveCommand, CleanCommand
 │           └── common.py        # Common utilities (asset paths, directory cleanup)
 │
 └── tests/                       # Test suite
-    ├── __init__.py
-    ├── smoke_test.py            # Smoke tests
-    ├── test_config.py           # Configuration tests
-    ├── test_plugin.py           # Plugin tests
-    ├── test_cli_*.py            # CLI tests
-    └── test.sh                  # Test runner script
 ```
 
 ### Module Responsibilities
@@ -133,11 +132,13 @@ mkdocs-note/
 | Module | Responsibility | Key Functions |
 |--------|---------------|---------------|
 | `plugin.py` | MkDocs plugin integration | File processing, recent notes insertion, graph integration |
-| `cli.py` | CLI entry point | Command registration, argument parsing, error handling |
-| `config.py` | Configuration | Plugin settings (`notes_root`, `recent_notes_config`, `graph_config`) |
+| `cli.py` | CLI entry point | Command registration (`new`/`remove`/`move`/`clean`/`notion-sync`), mkdocs.yml load for sync |
+| `config.py` | Configuration | Plugin settings (`notes_root`, `recent_notes_config`, `graph_config`, `notion_sync`) |
 | `graph.py` | Network graph | Node/edge creation, link detection, static asset management |
-| `utils/meta.py` | Metadata | Frontmatter validation, title/date extraction |
+| `utils/meta.py` | Metadata | Frontmatter validation (File), path-level parse / tags |
 | `utils/scanner.py` | File scanning | Note file discovery and validation |
+| `utils/tree.py` | Page tree | `.nav.yml` parse or `notes_root` directory hierarchy |
+| `utils/notion/` | Notion sync | convert / client / sync orchestration |
 | `utils/cli/commands.py` | CLI commands | `new`, `remove`, `move`, `clean` implementations |
 | `utils/cli/common.py` | CLI utilities | Asset directory paths, directory cleanup |
 
@@ -150,18 +151,25 @@ graph TB
         CLI[cli.py<br/>CLI Entry]
     end
     
-    subgraph "Independet Modules"
+    subgraph "Independent Modules"
         Config[config.py<br/>MkdocsNoteConfig]
-        Graph[graph.py<br/>Graph<br/>add_static_resources<br/>inject_graph_script<br/>copy_static_assets]
+        Graph[graph.py<br/>Graph]
     end
     
     subgraph "Utils Layer"
-        Meta[utils/meta.py<br/>validate_frontmatter<br/>extract_date<br/>extract_title]
-        Scanner[utils/scanner.py<br/>scan_notes]
+        Meta[utils/meta.py]
+        Scanner[utils/scanner.py]
+        Tree[utils/tree.py]
+        
+        subgraph "Notion"
+            Convert[notion/convert.py]
+            Client[notion/client.py]
+            Sync[notion/sync.py]
+        end
         
         subgraph "CLI Submodule"
-            Commands[cli/commands.py<br/>NewCommand<br/>RemoveCommand<br/>MoveCommand<br/>CleanCommand]
-            Common[cli/common.py<br/>get_asset_directory<br/>cleanup_empty_directories]
+            Commands[cli/commands.py]
+            Common[cli/common.py]
         end
     end
     
@@ -170,13 +178,17 @@ graph TB
     Plugin --> Meta
     Plugin --> Graph
     
-    CLI ---> Config
+    CLI --> Config
     CLI --> Commands
+    CLI --> Sync
     
     Commands --> Common
     Scanner --> Meta
-    
-    Common -->|Get MkDocsConfig Instance| Plugin
+    Sync --> Convert
+    Sync --> Client
+    Sync --> Meta
+    Sync --> Tree
+    Convert --> Meta
 ```
 
 ---
@@ -243,20 +255,20 @@ def cli():
 
 ```python
 class MkdocsNoteConfig(Config):
-    enabled: bool = True
-    notes_root: Path = "docs"
-    
-    recent_notes_config: dict = {
-        "enabled": False,
-        "insert_marker": "<!-- recent_notes -->",
-        "insert_num": 10,
-    }
-    
-    graph_config: dict = {
-        "enabled": False,
-        "name": "title",      # or "file_name"
-        "debug": False,
-    }
+	enabled: bool = True
+	notes_root: Path = "docs"
+
+	recent_notes_config: dict = {
+		"enabled": False,
+		"insert_marker": "<!-- recent_notes -->",
+		"insert_num": 10,
+	}
+
+	graph_config: dict = {
+		"enabled": False,
+		"name": "title",  # or "file_name"
+		"debug": False,
+	}
 ```
 
 ### graph.py - Network Graph Visualization
@@ -293,21 +305,23 @@ class Graph:
 
 ```python
 def validate_frontmatter(f: File) -> bool:
-    """Validate frontmatter, extract date and title.
-    
-    Required fields:
-    - date: datetime object
-    - title: string
-    - publish: bool (default True)
-    
-    Side effects: Sets f.note_date and f.note_title
-    """
+	"""Validate frontmatter, extract date and title.
+
+	Required fields:
+	- date: datetime object
+	- title: string
+	- publish: bool (default True)
+
+	Side effects: Sets f.note_date and f.note_title
+	"""
+
 
 def extract_date(f: File) -> Optional[datetime]:
-    """Extract date from validated file."""
+	"""Extract date from validated file."""
+
 
 def extract_title(f: File) -> Optional[str]:
-    """Extract title from validated file."""
+	"""Extract title from validated file."""
 ```
 
 **Validation Rules**:
@@ -324,16 +338,16 @@ def extract_title(f: File) -> Optional[str]:
 
 ```python
 def scan_notes(files: Files, config) -> tuple[list[File], list[File]]:
-    """Scan notes directory, return (valid_notes, invalid_files).
-    
-    Filtering:
-    1. Only documentation pages (is_documentation_page())
-    2. Within notes_root directory
-    3. Valid frontmatter (validate_frontmatter())
-    
-    Returns:
-        (valid_notes, invalid_files)
-    """
+	"""Scan notes directory, return (valid_notes, invalid_files).
+
+	Filtering:
+	1. Only documentation pages (is_documentation_page())
+	2. Within notes_root directory
+	3. Valid frontmatter (validate_frontmatter())
+
+	Returns:
+	    (valid_notes, invalid_files)
+	"""
 ```
 
 **MkDocs Integration**:
@@ -368,14 +382,16 @@ class XxxCommand:
 
 ```python
 def get_asset_directory(note_path: Path) -> Path:
-    """Co-located asset structure: note.parent / 'assets' / note.stem"""
-    return note_path.parent / "assets" / note_path.stem
+	"""Co-located asset structure: note.parent / 'assets' / note.stem"""
+	return note_path.parent / "assets" / note_path.stem
+
 
 def cleanup_empty_directories(start_dir: Path, stop_at: Path):
-    """Recursively remove empty parent directories."""
-    
+	"""Recursively remove empty parent directories."""
+
+
 def ensure_parent_directory(path: Path):
-    """Create parent directory if needed."""
+	"""Create parent directory if needed."""
 ```
 
 **Asset Directory Pattern**:
@@ -397,15 +413,15 @@ In v3.0.0+, we **leverage MkDocs' existing data structures** instead of creating
 ```python
 # MkDocs File object (extended by plugin)
 class File:
-    src_path: str              # Source path relative to docs_dir
-    abs_src_path: str          # Absolute source path
-    url: str                   # URL path for the file
-    content_string: str        # File content
-    page: Optional[Page]       # Associated Page object
-    
-    # Plugin-added attributes (via setattr):
-    note_date: datetime        # From frontmatter
-    note_title: str            # From frontmatter
+	src_path: str  # Source path relative to docs_dir
+	abs_src_path: str  # Absolute source path
+	url: str  # URL path for the file
+	content_string: str  # File content
+	page: Optional[Page]  # Associated Page object
+
+	# Plugin-added attributes (via setattr):
+	note_date: datetime  # From frontmatter
+	note_title: str  # From frontmatter
 ```
 
 ### Frontmatter Schema
@@ -732,10 +748,12 @@ sequenceDiagram
 ```python
 # v3.0.0: Direct, simple
 from mkdocs.utils import meta
+
 frontmatter, body = meta.get_data(content)
 
 # v2.x: Over-abstracted
 from mkdocs_note.utils.dataps.frontmatter.handlers import FrontmatterParser
+
 parser = FrontmatterParser()
 frontmatter, body = parser.parse(content)
 ```
@@ -769,7 +787,7 @@ docs/notes/python/intro.md
 **Implementation**:
 ```python
 def get_asset_directory(note_path: Path) -> Path:
-    return note_path.parent / "assets" / note_path.stem
+	return note_path.parent / "assets" / note_path.stem
 ```
 
 **Advantages**:
@@ -789,19 +807,19 @@ def get_asset_directory(note_path: Path) -> Path:
 ```python
 # Frontmatter validation
 if not frontmatter.get("publish", False):
-    logger.debug(f"Skipping {f.src_uri} because it is not published")
-    return False
+	logger.debug(f"Skipping {f.src_uri} because it is not published")
+	return False
 
 if "date" not in frontmatter:
-    logger.error(f"Invalid frontmatter for {f.src_uri}: 'date' is required")
-    return False
+	logger.error(f"Invalid frontmatter for {f.src_uri}: 'date' is required")
+	return False
 ```
 
 **CLI Error Handling**:
 ```python
 if not note_path.exists():
-    click.echo(f"❌ Error: File does not exist: {note_path}", err=True)
-    sys.exit(1)
+	click.echo(f"❌ Error: File does not exist: {note_path}", err=True)
+	sys.exit(1)
 ```
 
 ### Testing Strategy
@@ -887,7 +905,7 @@ docs/notes/python/intro.md
 ```python
 # Single source of truth
 def get_asset_directory(note_path: Path) -> Path:
-    return note_path.parent / "assets" / note_path.stem
+	return note_path.parent / "assets" / note_path.stem
 ```
 
 ### Why Use MkDocs' Built-in Frontmatter Parsing?
@@ -908,13 +926,15 @@ def get_asset_directory(note_path: Path) -> Path:
 ```python
 # v2.x: Custom parser (~200 lines)
 from mkdocs_note.utils.dataps.frontmatter.handlers import FrontmatterParser
+
 parser = FrontmatterParser()
 fm, body = parser.parse_file(path)
 
 # v3.0.0: Built-in (~5 lines)
 from mkdocs.utils import meta
+
 with open(path) as f:
-    fm, body = meta.get_data(f.read())
+	fm, body = meta.get_data(f.read())
 ```
 
 ### Why Remove Template System?
@@ -941,9 +961,9 @@ with open(path) as f:
 ```python
 # Simple, direct frontmatter generation
 def _generate_note_basic_meta(self, file_path: Path) -> str:
-    return f"""---
-date: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
-title: {file_path.stem.replace('-', ' ').title()}
+	return f"""---
+date: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}
+title: {file_path.stem.replace("-", " ").title()}
 permalink: 
 publish: true
 ---

--- a/docs/references/utils-layers.md
+++ b/docs/references/utils-layers.md
@@ -13,8 +13,18 @@ This section is about the underlying utility functions that are used in the plug
 
 And specifically, the `common` module of [CLI](cli-api.md) will call [plugin core](config-api.md) to get the plugin configuration instance, and `scanner` module will call `meta` module to validate the note file's frontmatter.
 
+Notion sync lives under `mkdocs_note.utils.notion` and is invoked only from the CLI (`notion-sync` / `ns`), not from MkDocs build hooks.
+
+## Developer note: Cursor MCP token (optional)
+
+`notion_sync.allow_cursor_mcp_token` (default `false`) may allow reading a Notion token from `~/.cursor/mcp.json` for local developer convenience. When a token is loaded this way, a warning is emitted unless `silence_mcp_token_warning: true`. Prefer `NOTION_TOKEN` / project `.env` for normal use. This option is intentionally omitted from the user handbook.
+
 ## ::: mkdocs_note.utils.meta
 
 ## ::: mkdocs_note.utils.scanner
+
+## ::: mkdocs_note.utils.tree
+
+## ::: mkdocs_note.utils.notion
 
 ## ::: mkdocs_note.utils.cli

--- a/docs/usage/cli.md
+++ b/docs/usage/cli.md
@@ -23,6 +23,7 @@ In `v3.0.x`, there only has commands to create, remove, move notes with there co
 | `remove` | Remove a note file and its corresponding asset directory. |
 | `move` | Move a note file and its corresponding asset directory to a new location. |
 | `clean` | Clean up orphaned asset directories. |
+| `notion-sync` (`ns`) | Sync notes to a Notion wiki (incremental via git diff). |
 
 ## Commands Detail
 
@@ -101,9 +102,13 @@ Remove a note file and its corresponding asset directory.
 - **Features:**
 
     - Removes both the note file and its corresponding asset directory by default
+
     - Supports removing single files or entire directories containing notes
+
     - Prompts for confirmation before deletion (unless `--yes` is used)
+
     - Automatically cleans up empty parent directories after removal
+
     - Supports both `.md` and `.ipynb` file formats
 
 - **Examples:**
@@ -327,3 +332,18 @@ mkdocs-note clean [OPTIONS]
     🗑️  Removing orphaned assets...
     ✅ Successfully removed 3 orphaned asset directories
     ```
+
+### `notion-sync`
+
+Sync MkDocs notes to a Notion wiki database (incremental via git diff by default).
+
+- **Aliases:** `ns`
+
+- **Usage:**
+
+    ```bash
+    mkdocs-note notion-sync [OPTIONS]
+    mkdocs-note ns --dry-run --full
+    ```
+
+- See [Notion Sync](notion-sync.md) for configuration, token setup, and behaviour details.

--- a/docs/usage/config.md
+++ b/docs/usage/config.md
@@ -1,8 +1,76 @@
 ---
-date: 2025-10-17 11:19:45
+date: 2026-08-03 00:35:00
 title: Configuration Options
 permalink: 
-publish: false
+publish: true
 ---
 
 # Configuration Options
+
+Configure the plugin under `plugins` in `mkdocs.yml`:
+
+```yaml
+plugins:
+  - mkdocs-note:
+      enabled: true
+      notes_root: docs
+      recent_notes_config:
+        enabled: false
+        insert_marker: "<!-- recent_notes -->"
+        insert_num: 10
+      graph_config:
+        enabled: false
+        name: title
+        debug: false
+      notion_sync:
+        docs_dir: docs
+        nav_file: docs/.nav.yml
+        database_id: ""
+        data_source_id: ""
+        title_property: "页面"
+        tags_property: "标签"
+        site_url: ""
+        state_path: ".notion_sync_state.json"
+        delay: 0.35
+```
+
+## Core
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `true` | Enable or disable the plugin |
+| `notes_root` | `docs` | Working directory for note scanning and CLI |
+
+## Recent notes
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `recent_notes_config.enabled` | `false` | Insert a recent-notes list |
+| `recent_notes_config.insert_marker` | `<!-- recent_notes -->` | Marker in the index page |
+| `recent_notes_config.insert_num` | `10` | How many notes to list |
+
+## Network graph
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `graph_config.enabled` | `false` | Enable graph visualization |
+| `graph_config.name` | `title` | Node label: `title` or `file_name` |
+| `graph_config.debug` | `false` | Extra graph logging |
+
+## Notion sync
+
+Used by `mkdocs-note notion-sync` / `ns`. See [Notion Sync](notion-sync.md).
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `notion_sync.docs_dir` | `docs` | Docs root for paths / git diff |
+| `notion_sync.nav_file` | `docs/.nav.yml` | awesome-nav file (fallback: directory scan) |
+| `notion_sync.database_id` | `""` | Notion wiki database ID (or env) |
+| `notion_sync.data_source_id` | `""` | Notion data source ID (or env) |
+| `notion_sync.title_property` | `页面` | Title property name |
+| `notion_sync.tags_property` | `标签` | Multi-select tags property |
+| `notion_sync.site_url` | `""` | Public site URL; falls back to mkdocs `site_url` |
+| `notion_sync.state_path` | `.notion_sync_state.json` | Local page map (gitignore) |
+| `notion_sync.delay` | `0.35` | Delay between API calls (seconds) |
+
+Token is never stored in `mkdocs.yml` — use environment variables or local token files.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -10,3 +10,5 @@ publish: true
 This is the user guide of the `mkdocs-note` plugin in detail. You can get more details about the usage and features of the plugin here.
 
 For the quick start, you can refer to the [Getting Started](../getting-started.md) guide.
+
+Topics include recent notes, the CLI, asset management, the network graph, [Notion sync](notion-sync.md), and [configuration](config.md).

--- a/docs/usage/notion-sync.md
+++ b/docs/usage/notion-sync.md
@@ -1,0 +1,108 @@
+---
+date: 2026-08-03 00:30:00
+title: Notion Sync
+permalink: 
+publish: true
+---
+
+# Notion Sync
+
+Sync your MkDocs notes to a Notion wiki database. The CLI uses git-diff
+incremental sync by default so routine commits only touch changed pages.
+
+## Prerequisites
+
+- A Notion integration token (`NOTION_TOKEN` or `NOTION_API_KEY`)
+
+- Wiki **database ID** and **data source ID** for your Notebook wiki
+
+- Recommended: [mkdocs-awesome-nav](https://github.com/lukasgeiter/mkdocs-awesome-nav)
+  with a `docs/.nav.yml` so Notion sections match your site navigation
+
+If `.nav.yml` is missing, the CLI falls back to scanning `notes_root` and
+preserves directory hierarchy. A warning is logged recommending awesome-nav.
+
+## Configuration
+
+Add a `notion_sync` block under the plugin in `mkdocs.yml`:
+
+```yaml
+plugins:
+  - mkdocs-note:
+      notes_root: docs
+      notion_sync:
+        docs_dir: docs
+        nav_file: docs/.nav.yml
+        database_id: "<your-database-id>"
+        data_source_id: "<your-data-source-id>"
+        title_property: "页面"
+        tags_property: "标签"
+        site_url: "https://example.com"   # optional; also falls back to mkdocs site_url
+        state_path: ".notion_sync_state.json"
+        delay: 0.35
+```
+
+Sensitive credentials stay in the environment (or local files), not in git:
+
+1. CLI `--token`
+
+2. `NOTION_TOKEN` / `NOTION_API_KEY`
+
+3. Project `.env` / `.notion_token` (do not commit)
+
+4. `~/.config/notion/token`
+
+Environment overrides for IDs: `NOTION_WIKI_DATABASE`, `NOTION_WIKI_DATA_SOURCE`,
+`NOTION_TITLE_PROPERTY`, `NOTION_TAGS_PROPERTY`, `NOTION_STATE_PATH`.
+
+Add `.notion_sync_state.json` to `.gitignore`. In CI, cache that file so page
+maps do not rebuild every run.
+
+## Usage
+
+```bash
+# Incremental (relative to HEAD~1 or GITHUB_EVENT_BEFORE)
+mkdocs-note notion-sync
+# short alias
+mkdocs-note ns
+
+# Full sync / section filter / dry-run
+mkdocs-note notion-sync --full
+mkdocs-note ns --section notes/
+mkdocs-note notion-sync --dry-run --paths notes/intro.md
+mkdocs-note notion-sync --rebuild-state
+```
+
+### Common flags
+
+| Flag | Meaning |
+|------|---------|
+| `--full` | Sync all nav pages |
+| `--base REF` | Git base for diff (`full` forces full sync) |
+| `--paths` / `--paths-file` | Explicit file list |
+| `--section PREFIX` | Limit to path prefixes |
+| `--dry-run` | Convert and log without writing Notion |
+| `--no-images` | Skip local image uploads |
+| `--rebuild-state` | Remap pages from the wiki |
+
+## Behaviour notes
+
+- Structure follows `.nav.yml` (or directory hierarchy on fallback)
+
+- Local deletions are logged only — Notion pages are **not** deleted
+
+- All `index.md` pages are skipped
+
+- Frontmatter `tags` / `tag` map to the Notion multi-select property
+
+- Local images upload via Notion File Upload + block insert (not site URLs)
+
+- Material tabs become heading sections; admonitions become callouts / details
+
+## Known limitations
+
+- Same-parent duplicate titles can mis-match during `--rebuild-state`
+
+- Full sync with many local images is slow — prefer incremental
+
+- Some Material features (inline float admonitions, true tabs) are approximated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mkdocs-note"
-version = "3.1.2"
+version = "3.2.0"
 description = "A MkDocs plugin to add note boxes to your documentation."
 readme = "README.md"
 requires-python = ">=3.12"
@@ -71,8 +71,13 @@ quote-style = "double"
 
 # Per-file rule ignores
 [tool.ruff.lint.per-file-ignores]
-# 忽略 __init__.py 文件中的 F401 (导入未被使用)
+# Unused imports in package init
 "__init__.py" = ["F401"]
+# CLI / smoke tests intentionally catch Exception at top level for UX
+"src/mkdocs_note/cli.py" = ["BLE001"]
+"src/mkdocs_note/utils/cli/**" = ["BLE001"]
+"tests/smoke_test.py" = ["BLE001"]
+"scripts/**" = ["BLE001"]
 
 
 [tool.uv]

--- a/scripts/hooks/rss.py
+++ b/scripts/hooks/rss.py
@@ -14,7 +14,7 @@ log = logging.getLogger("mkdocs.plugins")
 
 
 def get_content(config: MkDocsConfig) -> str:
-	now = datetime.datetime.now(datetime.timezone.utc)
+	now = datetime.datetime.now(datetime.UTC)
 	build_datetime = html.escape(email.utils.format_datetime(now))
 	return inspect.cleandoc(f'''
         <?xml version="1.0" encoding="UTF-8" ?>

--- a/src/mkdocs_note/__init__.py
+++ b/src/mkdocs_note/__init__.py
@@ -1,11 +1,11 @@
-from datetime import datetime
+from datetime import UTC, datetime, timezone
 
 __author__ = "virtualguard101"
 __description__ = "A MkDocs plugin to add note boxes to your documentation."
 __license__ = "GPL-3.0-or-later"
 __url__ = "https://github.com/virtualguard101/mkdocs-note"
 __email__ = "virtualguard101@gmail.com"
-__copyright__ = f"Copyright {datetime.now().year} virtualguard101"
+__copyright__ = f"Copyright {datetime.now(UTC).year} virtualguard101"
 
 try:
 	from ._version import __version__

--- a/src/mkdocs_note/cli.py
+++ b/src/mkdocs_note/cli.py
@@ -7,18 +7,173 @@ independent of MkDocs plugin system.
 """
 
 import sys
-import click
-from pathlib import Path
 from importlib import metadata
+from pathlib import Path
+from typing import Any
 
+import click
+import yaml
+from yaml.nodes import MappingNode, ScalarNode, SequenceNode
+
+import mkdocs_note.utils.cli.common as cli_common
 from mkdocs_note.config import MkdocsNoteConfig
 from mkdocs_note.utils.cli.commands import (
+	CleanCommand,
+	MoveCommand,
 	NewCommand,
 	RemoveCommand,
-	MoveCommand,
-	CleanCommand,
 )
-import mkdocs_note.utils.cli.common as cli_common
+from mkdocs_note.utils.notion.sync import SyncOptions, run_sync, setup_logging
+
+
+class _IgnoreUnknownLoader(yaml.SafeLoader):
+	"""SafeLoader that ignores MkDocs / pymdownx Python object tags."""
+
+
+def _ignore_unknown(loader: yaml.SafeLoader, tag_suffix: str, node: yaml.Node):
+	if isinstance(node, ScalarNode):
+		return loader.construct_scalar(node)
+	if isinstance(node, SequenceNode):
+		return loader.construct_sequence(node)
+	if isinstance(node, MappingNode):
+		return loader.construct_mapping(node)
+	return None
+
+
+_IgnoreUnknownLoader.add_multi_constructor("!", _ignore_unknown)
+_IgnoreUnknownLoader.add_multi_constructor("tag:yaml.org,2002:python/", _ignore_unknown)
+
+
+def _load_yaml_file(path: Path) -> dict[str, Any]:
+	"""Load YAML, tolerating MkDocs-specific tags."""
+	with path.open("r", encoding="utf-8") as f:
+		data = yaml.load(f, Loader=_IgnoreUnknownLoader)
+	return data if isinstance(data, dict) else {}
+
+
+def find_project_root(start: Path | None = None) -> Path:
+	"""Walk parents looking for ``mkdocs.yml`` / ``mkdocs.yaml``.
+
+	Args:
+	    start: Starting directory (default: cwd).
+
+	Returns:
+	    Path to the project root (falls back to cwd if not found).
+	"""
+	cur = (start or Path.cwd()).resolve()
+	for candidate in [cur, *cur.parents]:
+		if (candidate / "mkdocs.yml").is_file() or (
+			candidate / "mkdocs.yaml"
+		).is_file():
+			return candidate
+	return cur
+
+
+def load_mkdocs_plugin_section(project_root: Path) -> dict[str, Any]:
+	"""Load the ``mkdocs-note`` plugin config dict from ``mkdocs.yml``.
+
+	Args:
+	    project_root: Directory containing mkdocs.yml.
+
+	Returns:
+	    Plugin configuration mapping (may be empty). Includes ``_site_url``
+	    from the top-level mkdocs.yml when present.
+	"""
+	for name in ("mkdocs.yml", "mkdocs.yaml"):
+		path = project_root / name
+		if not path.is_file():
+			continue
+		data = _load_yaml_file(path)
+		result: dict[str, Any] = {}
+		if data.get("site_url"):
+			result["_site_url"] = data["site_url"]
+		plugins = data.get("plugins") or []
+		for entry in plugins:
+			if entry == "mkdocs-note":
+				return result
+			if isinstance(entry, dict) and "mkdocs-note" in entry:
+				cfg = entry["mkdocs-note"]
+				if isinstance(cfg, dict):
+					merged = dict(cfg)
+					merged.update({k: v for k, v in result.items() if k not in merged})
+					return merged
+				return result
+		return result
+	return {}
+
+
+def build_sync_options_from_config(
+	project_root: Path,
+	*,
+	full: bool = False,
+	base: str | None = None,
+	paths: tuple[str, ...] | None = None,
+	paths_file: Path | None = None,
+	section: tuple[str, ...] | None = None,
+	site_url: str | None = None,
+	state: Path | None = None,
+	database_id: str | None = None,
+	data_source_id: str | None = None,
+	token: str | None = None,
+	rebuild_state: bool = False,
+	no_images: bool = False,
+	dry_run: bool = False,
+	continue_on_error: bool = False,
+	verbose: bool = False,
+	delay: float | None = None,
+) -> SyncOptions:
+	"""Assemble ``SyncOptions`` from mkdocs.yml plugin section + CLI overrides."""
+	plugin = load_mkdocs_plugin_section(project_root)
+	ns = (
+		plugin.get("notion_sync") if isinstance(plugin.get("notion_sync"), dict) else {}
+	)
+
+	notes_root_raw = plugin.get("notes_root") or "docs"
+	docs_dir_raw = ns.get("docs_dir") or notes_root_raw or "docs"
+	nav_file_raw = ns.get("nav_file") or f"{docs_dir_raw}/.nav.yml"
+
+	def _abs(p: str | Path) -> Path:
+		path = Path(p)
+		return path if path.is_absolute() else (project_root / path)
+
+	resolved_site = (
+		site_url
+		if site_url is not None
+		else (ns.get("site_url") or plugin.get("_site_url") or "")
+	)
+
+	return SyncOptions(
+		project_root=project_root,
+		docs_dir=_abs(docs_dir_raw),
+		notes_root=_abs(notes_root_raw),
+		nav_file=_abs(nav_file_raw) if nav_file_raw else None,
+		database_id=database_id
+		if database_id is not None
+		else str(ns.get("database_id") or ""),
+		data_source_id=data_source_id
+		if data_source_id is not None
+		else str(ns.get("data_source_id") or ""),
+		title_property=str(ns.get("title_property") or "页面"),
+		tags_property=str(ns.get("tags_property") or "标签"),
+		site_url=str(resolved_site),
+		state_path=_abs(state)
+		if state is not None
+		else _abs(ns.get("state_path") or ".notion_sync_state.json"),
+		delay=float(delay if delay is not None else ns.get("delay", 0.35)),
+		token=token,
+		allow_cursor_mcp_token=bool(ns.get("allow_cursor_mcp_token", False)),
+		silence_mcp_token_warning=bool(ns.get("silence_mcp_token_warning", False)),
+		full=full,
+		base=base,
+		paths=list(paths) if paths else None,
+		paths_file=paths_file,
+		section=list(section) if section else None,
+		rebuild_state=rebuild_state,
+		no_images=no_images,
+		dry_run=dry_run,
+		continue_on_error=continue_on_error,
+		verbose=verbose,
+	)
 
 
 def get_version():
@@ -70,7 +225,7 @@ class CustomGroup(click.Group):
 
 		# Group commands by their main command (excluding aliases)
 		command_groups = {}
-		alias_map = {"rm": "remove", "mv": "move"}
+		alias_map = {"rm": "remove", "mv": "move", "ns": "notion-sync"}
 
 		for name, command in commands:
 			if name in alias_map:
@@ -531,10 +686,11 @@ def clean_command(ctx, dry_run, yes):
 			sys.exit(0)
 
 		# Confirmation prompt (unless --yes)
-		if not yes:
-			if not click.confirm(f"\nRemove these {len(orphaned_dirs)} directories?"):
-				click.echo("⚠️  Cancelled")
-				sys.exit(0)
+		if not yes and not click.confirm(
+			f"\nRemove these {len(orphaned_dirs)} directories?"
+		):
+			click.echo("⚠️  Cancelled")
+			sys.exit(0)
 
 		# Actually clean
 		click.echo("\n🗑️ Removing orphaned assets...")
@@ -548,6 +704,138 @@ def clean_command(ctx, dry_run, yes):
 	except Exception as e:
 		click.echo(f"❌ Unexpected error: {e}", err=True)
 		sys.exit(1)
+
+
+@cli.command("notion-sync")
+@click.option("--full", is_flag=True, help="Process all nav pages (ignore git diff)")
+@click.option(
+	"--base",
+	help="Git base ref for diff (default: GITHUB_EVENT_BEFORE / HEAD~1). "
+	"Use 'full' to force full sync.",
+)
+@click.option(
+	"--paths",
+	multiple=True,
+	help="Only sync these docs-relative paths (skip git diff). Repeatable.",
+)
+@click.option(
+	"--paths-file",
+	type=click.Path(path_type=Path),
+	help="Newline-separated docs-relative paths (handles spaces safely)",
+)
+@click.option("--site-url", default=None, help="Override site_url from mkdocs.yml")
+@click.option(
+	"--state",
+	type=click.Path(path_type=Path),
+	default=None,
+	help="Path to .notion_sync_state.json",
+)
+@click.option("--database-id", default=None, help="Notion wiki database / page ID")
+@click.option("--data-source-id", default=None, help="Notion data source ID")
+@click.option(
+	"--section",
+	multiple=True,
+	help="Limit to path prefixes, e.g. notes/. Repeatable.",
+)
+@click.option("--delay", type=float, default=None, help="Delay between API calls")
+@click.option("--token", default=None, help="Notion integration token")
+@click.option(
+	"--rebuild-state",
+	is_flag=True,
+	help="Remap pages from Notion wiki before syncing",
+)
+@click.option("--no-images", is_flag=True, help="Skip local image upload")
+@click.option("--dry-run", is_flag=True, help="Convert and log without writing Notion")
+@click.option(
+	"--continue-on-error",
+	is_flag=True,
+	help="Continue syncing after a page failure",
+)
+@click.option("-v", "--verbose", is_flag=True, help="Debug logging")
+@click.pass_context
+def notion_sync_command(
+	ctx,
+	full,
+	base,
+	paths,
+	paths_file,
+	site_url,
+	state,
+	database_id,
+	data_source_id,
+	section,
+	delay,
+	token,
+	rebuild_state,
+	no_images,
+	dry_run,
+	continue_on_error,
+	verbose,
+):
+	"""Sync MkDocs notes to a Notion wiki (incremental via git diff).
+
+	\b
+	Aliases: ns
+
+	\b
+	Examples:
+	    mkdocs-note notion-sync --dry-run
+	    mkdocs-note ns --full --section notes/
+	    mkdocs-note notion-sync --paths notes/intro.md
+	"""
+	setup_logging(verbose)
+	project_root = find_project_root()
+	try:
+		options = build_sync_options_from_config(
+			project_root,
+			full=full,
+			base=base,
+			paths=paths or None,
+			paths_file=paths_file,
+			section=section or None,
+			site_url=site_url,
+			state=state,
+			database_id=database_id,
+			data_source_id=data_source_id,
+			token=token,
+			rebuild_state=rebuild_state,
+			no_images=no_images,
+			dry_run=dry_run,
+			continue_on_error=continue_on_error,
+			verbose=verbose,
+			delay=delay,
+		)
+		code = run_sync(options)
+		sys.exit(code)
+	except KeyboardInterrupt:
+		click.echo("Interrupted", err=True)
+		sys.exit(130)
+	except Exception as e:
+		click.echo(f"❌ Unexpected error: {e}", err=True)
+		sys.exit(1)
+
+
+@cli.command("ns")
+@click.option("--full", is_flag=True)
+@click.option("--base", default=None)
+@click.option("--paths", multiple=True)
+@click.option("--paths-file", type=click.Path(path_type=Path), default=None)
+@click.option("--site-url", default=None)
+@click.option("--state", type=click.Path(path_type=Path), default=None)
+@click.option("--database-id", default=None)
+@click.option("--data-source-id", default=None)
+@click.option("--section", multiple=True)
+@click.option("--delay", type=float, default=None)
+@click.option("--token", default=None)
+@click.option("--rebuild-state", is_flag=True)
+@click.option("--no-images", is_flag=True)
+@click.option("--dry-run", is_flag=True)
+@click.option("--continue-on-error", is_flag=True)
+@click.option("-v", "--verbose", is_flag=True)
+@click.pass_context
+def ns_command(ctx, **kwargs):
+	"""Alias for 'notion-sync' — Sync notes to Notion wiki."""
+	ctx.invoke(notion_sync_command, **kwargs)
 
 
 if __name__ == "__main__":

--- a/src/mkdocs_note/config.py
+++ b/src/mkdocs_note/config.py
@@ -44,3 +44,35 @@ class MkdocsNoteConfig(Config):
     - name: Node naming strategy ("title" or "file_name")
     - debug: Enable debug logging for graph generation
     """
+
+	notion_sync = config_opt.Type(
+		dict,
+		default={
+			"docs_dir": "docs",
+			"nav_file": "docs/.nav.yml",
+			"database_id": "",
+			"data_source_id": "",
+			"title_property": "页面",
+			"tags_property": "标签",
+			"site_url": "",
+			"state_path": ".notion_sync_state.json",
+			"delay": 0.35,
+			"allow_cursor_mcp_token": False,
+			"silence_mcp_token_warning": False,
+		},
+	)
+	"""Configuration for Notion wiki sync (CLI: ``mkdocs-note notion-sync``).
+
+    Available options:
+    - docs_dir: Documentation root (git diff / relative path base)
+    - nav_file: Path to awesome-nav ``.nav.yml`` (relative to project root)
+    - database_id: Notion wiki database / page ID (or env NOTION_WIKI_DATABASE)
+    - data_source_id: Notion data source ID (or env NOTION_WIKI_DATA_SOURCE)
+    - title_property: Title property name (default: 页面)
+    - tags_property: Multi-select tags property name (default: 标签)
+    - site_url: Public site URL for remote image fallbacks
+    - state_path: Local page-map JSON path
+    - delay: Seconds between Notion API calls
+    - allow_cursor_mcp_token: Developer-only; allow reading token from Cursor mcp.json
+    - silence_mcp_token_warning: Suppress the MCP-token usage warning
+    """

--- a/src/mkdocs_note/graph.py
+++ b/src/mkdocs_note/graph.py
@@ -6,11 +6,11 @@ Migrated from [mkdocs-network-graph-plugin](https://github.com/develmusa/mkdocs-
 import os
 import re
 import shutil
-from typing import Iterator, Optional
-from urllib.parse import unquote, urlsplit, urlparse
+from collections.abc import Iterator
+from urllib.parse import unquote, urlparse, urlsplit
 
-from mkdocs.plugins import get_plugin_logger
 from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.plugins import get_plugin_logger
 from mkdocs.structure.files import Files
 from mkdocs.structure.pages import Page
 
@@ -67,7 +67,7 @@ class Graph:
 			url = url[1:-1]
 		return unquote(url)
 
-	def _normalize_link(self, match: re.Match) -> Optional[str]:
+	def _normalize_link(self, match: re.Match) -> str | None:
 		"""Normalize the URL from a regex match."""
 		url = match.group("url") or match.group("wikilink")
 		if not url:
@@ -108,7 +108,6 @@ class Graph:
 			except FileNotFoundError:
 				logger.warning(f"File not found: {node['path']}")
 				# This should not happen if the file is in the `files` collection
-				pass
 		logger.info(f"Created {len(self.edges)} edges")
 
 	def __call__(self, files: Files):

--- a/src/mkdocs_note/plugin.py
+++ b/src/mkdocs_note/plugin.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
-import os
 import json
+import os
+from typing import ClassVar
 
-from mkdocs.structure.files import Files, File
 from mkdocs.config.defaults import MkDocsConfig
 from mkdocs.plugins import BasePlugin, event_priority, get_plugin_logger
-from mkdocs.structure.pages import Page
+from mkdocs.structure.files import File, Files
 from mkdocs.structure.nav import Navigation
+from mkdocs.structure.pages import Page
 
 from mkdocs_note.config import MkdocsNoteConfig
-from mkdocs_note.utils import scanner
-from mkdocs_note.utils.meta import extract_title, extract_date
 from mkdocs_note.graph import (
 	Graph,
 	add_static_resouces,
-	inject_graph_script,
 	copy_static_assets,
+	inject_graph_script,
 )
-
+from mkdocs_note.utils import scanner
+from mkdocs_note.utils.meta import extract_date, extract_title
 
 log = get_plugin_logger(__name__)
 
@@ -26,7 +26,7 @@ log = get_plugin_logger(__name__)
 class MkdocsNotePlugin(BasePlugin[MkdocsNoteConfig]):
 	"""Mkdocs Note Plugin entry point."""
 
-	notes_list: list[File] = []
+	notes_list: ClassVar[list[File]] = []
 
 	@event_priority(100)
 	def on_files(self, files: Files, config: MkDocsConfig) -> Files:
@@ -85,7 +85,7 @@ class MkdocsNotePlugin(BasePlugin[MkdocsNoteConfig]):
 			graph_file = os.path.join(output_dir, "graph.json")
 			with open(graph_file, "w") as f:
 				json.dump(self._graph.to_dict(), f)
-		except (IOError, OSError) as e:
+		except OSError as e:
 			log.error(f"Error writing graph file: {e}")
 
 	def on_post_page(
@@ -128,7 +128,7 @@ class MkdocsNotePlugin(BasePlugin[MkdocsNoteConfig]):
 		log.info("Copying static assets...")
 		try:
 			copy_static_assets(static_dir=self.static_dir, config=config)
-		except (IOError, OSError) as e:
+		except OSError as e:
 			log.error(f"Error copying static assets: {e}")
 
 	def on_page_markdown(

--- a/src/mkdocs_note/utils/cli/commands.py
+++ b/src/mkdocs_note/utils/cli/commands.py
@@ -1,6 +1,6 @@
 import shutil
+from datetime import UTC, datetime
 from pathlib import Path
-from datetime import datetime
 
 from mkdocs.plugins import get_plugin_logger
 
@@ -27,7 +27,7 @@ class NewCommand:
 		log.debug(f"Generating note meta for: {file_path} with permalink: {permalink}")
 
 		return f"""---
-date: {datetime.now().strftime(self.timestamp_format)}
+date: {datetime.now(UTC).strftime(self.timestamp_format)}
 title: {file_path.stem.replace("-", " ").replace("_", " ").title()}
 permalink: {permalink}
 publish: false

--- a/src/mkdocs_note/utils/cli/common.py
+++ b/src/mkdocs_note/utils/cli/common.py
@@ -3,14 +3,12 @@ Common utilities and data structures for CLI operations.
 """
 
 from pathlib import Path
-from typing import Optional
 
-from mkdocs.plugins import get_plugin_logger
 from mkdocs.config.defaults import MkDocsConfig
+from mkdocs.plugins import get_plugin_logger
 from mkdocs.utils import meta
 
 from mkdocs_note.plugin import MkdocsNotePlugin as plugin
-
 
 log = get_plugin_logger(__name__)
 
@@ -65,7 +63,7 @@ def get_asset_directory_by_permalink(note_path: Path, permalink: str) -> Path:
 	return note_path.parent / "assets" / permalink
 
 
-def get_permalink_from_file(note_path: Path) -> Optional[str]:
+def get_permalink_from_file(note_path: Path) -> str | None:
 	"""Extract permalink value from note file's frontmatter.
 
 	Args:

--- a/src/mkdocs_note/utils/meta.py
+++ b/src/mkdocs_note/utils/meta.py
@@ -1,25 +1,112 @@
-from datetime import datetime
-from typing import Optional
+"""Metadata helpers for note frontmatter.
 
-from mkdocs.utils import meta
+Supports both MkDocs ``File`` objects (plugin build path) and plain text / path
+APIs used by CLI tools such as Notion sync.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
 from mkdocs.plugins import get_plugin_logger
 from mkdocs.structure.files import File
-
+from mkdocs.utils import meta as mkdocs_meta
 
 logger = get_plugin_logger(__name__)
 
 
-def validate_frontmatter(f: File) -> bool:
-	"""Validate the frontmatter of the file
+def parse_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+	"""Split markdown text into frontmatter dict and body.
 
 	Args:
-	    file (File): The file to validate
+	    text: Full file contents.
 
 	Returns:
-	    bool: True if the frontmatter is valid, False otherwise
+	    Tuple of (metadata dict, body without frontmatter).
+	"""
+	if not text.startswith("---"):
+		return {}, text
+	end = text.find("\n---", 3)
+	if end == -1:
+		return {}, text
+	raw = text[3:end].strip()
+	body = text[end + 4 :].lstrip("\n")
+	if not raw:
+		return {}, body
+	try:
+		loaded = yaml.safe_load(raw)
+		meta_dict = loaded if isinstance(loaded, dict) else {}
+	except (yaml.YAMLError, AttributeError, TypeError):
+		# Fallback: flat key: value (no nested lists).
+		meta_dict = {}
+		for line in raw.splitlines():
+			if ":" not in line:
+				continue
+			key, value = line.split(":", 1)
+			key = key.strip()
+			value = value.strip()
+			if value.startswith('"') and value.endswith('"'):
+				value = value[1:-1]
+			meta_dict[key] = value
+	return meta_dict, body
+
+
+def parse_frontmatter_file(path: Path) -> tuple[dict[str, Any], str]:
+	"""Read a file and parse its frontmatter.
+
+	Args:
+	    path: Path to a markdown (or text) file.
+
+	Returns:
+	    Tuple of (metadata dict, body).
+	"""
+	raw = path.read_text(encoding="utf-8")
+	return parse_frontmatter(raw)
+
+
+def extract_tags(meta_dict: dict[str, Any]) -> list[str]:
+	"""Normalize frontmatter ``tags`` / ``tag`` into a list of non-empty strings.
+
+	Args:
+	    meta_dict: Parsed frontmatter mapping.
+
+	Returns:
+	    List of tag strings.
+	"""
+	raw = meta_dict.get("tags", meta_dict.get("tag", None))
+	if raw is None:
+		return []
+	if isinstance(raw, str):
+		parts = [p.strip() for p in re.split(r"[,;]", raw)]
+		return [p for p in parts if p]
+	if isinstance(raw, (list, tuple)):
+		out: list[str] = []
+		for item in raw:
+			if item is None:
+				continue
+			s = str(item).strip()
+			if s:
+				out.append(s)
+		return out
+	s = str(raw).strip()
+	return [s] if s else []
+
+
+def validate_frontmatter(f: File) -> bool:
+	"""Validate the frontmatter of the file.
+
+	Args:
+	    f: The file to validate.
+
+	Returns:
+	    bool: True if the frontmatter is valid, False otherwise.
 	"""
 	try:
-		_, frontmatter = meta.get_data(f.content_string)
+		_, frontmatter = mkdocs_meta.get_data(f.content_string)
 
 		if not frontmatter.get("publish", False):
 			logger.debug(f"Skipping {f.src_uri} because it is not published")
@@ -36,7 +123,7 @@ def validate_frontmatter(f: File) -> bool:
 			)
 			return False
 
-		setattr(f, "note_date", date)
+		f.note_date = date
 
 		if "title" not in frontmatter:
 			logger.error(f"Invalid frontmatter for {f.src_uri}: 'title' is required")
@@ -49,38 +136,39 @@ def validate_frontmatter(f: File) -> bool:
 			)
 			return False
 
-		setattr(f, "note_title", title)
+		f.note_title = title
 		return True
 
 	except Exception as e:
 		logger.error(f"Error validating frontmatter for {f.src_uri}: {e}")
-		raise e
+		raise
 
 
-def extract_date(f: File) -> Optional[datetime]:
-	"""Extract date from docs file
+def extract_date(f: File) -> datetime | None:
+	"""Extract date from docs file.
+
 	Args:
-	    f (File): The file to extract date from
+	    f: The file to extract date from.
 
 	Returns:
-	    Optional[datetime]: The date if successful, None otherwise
+	    Optional[datetime]: The date if successful, None otherwise.
 	"""
 	try:
 		return f.note_date
-	except Exception:
+	except AttributeError:
 		return None
 
 
-def extract_title(f: File) -> Optional[str]:
-	"""Extract title from docs file
+def extract_title(f: File) -> str | None:
+	"""Extract title from docs file.
 
 	Args:
-	    f (File): The file to extract title from
+	    f: The file to extract title from.
 
 	Returns:
-	    Optional[str]: The title if successful, None otherwise
+	    Optional[str]: The title if successful, None otherwise.
 	"""
 	try:
 		return f.note_title
-	except Exception:
+	except AttributeError:
 		return None

--- a/src/mkdocs_note/utils/notion/__init__.py
+++ b/src/mkdocs_note/utils/notion/__init__.py
@@ -1,0 +1,7 @@
+"""Notion sync utilities (convert / client / sync)."""
+
+from __future__ import annotations
+
+from mkdocs_note.utils.notion.sync import SyncOptions, run_sync
+
+__all__ = ["SyncOptions", "run_sync"]

--- a/src/mkdocs_note/utils/notion/client.py
+++ b/src/mkdocs_note/utils/notion/client.py
@@ -1,0 +1,489 @@
+"""Notion HTTP API helpers for page sync.
+
+Handles page create/update, tags schema, file uploads, and block operations.
+Wiki IDs are always passed by the caller — never hardcoded here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import mimetypes
+import re
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from mkdocs_note.utils.notion.convert import CONTENT_TYPES
+
+log = logging.getLogger("mkdocs_note.notion")
+
+NOTION_VERSION_PAGES = "2025-09-03"
+NOTION_VERSION_MARKDOWN = "2026-03-11"
+
+
+def notion_request(
+	token: str,
+	method: str,
+	path: str,
+	payload: dict | None = None,
+	notion_version: str = NOTION_VERSION_PAGES,
+	retries: int = 6,
+) -> dict:
+	"""Perform a Notion REST request with retries on transient failures.
+
+	Args:
+	    token: Notion integration bearer token.
+	    method: HTTP method (GET, POST, PATCH, DELETE, …).
+	    path: API path under ``https://api.notion.com/v1/``.
+	    payload: Optional JSON body.
+	    notion_version: Notion-Version header value.
+	    retries: Max attempts for rate-limit / network errors.
+
+	Returns:
+	    Parsed JSON response dict (empty if body is empty).
+	"""
+	import http.client
+	import ssl
+
+	url = f"https://api.notion.com/v1/{path}"
+	data = json.dumps(payload).encode("utf-8") if payload is not None else None
+	last_error: Exception | None = None
+	for attempt in range(retries):
+		try:
+			req = urllib.request.Request(
+				url,
+				data=data,
+				method=method,
+				headers={
+					"Authorization": f"Bearer {token}",
+					"Notion-Version": notion_version,
+					"Content-Type": "application/json",
+				},
+			)
+			with urllib.request.urlopen(req, timeout=180) as resp:
+				body = resp.read().decode("utf-8")
+				return json.loads(body) if body else {}
+		except urllib.error.HTTPError as exc:
+			last_error = exc
+			err_body = exc.read().decode("utf-8", errors="replace")
+			if exc.code in (429, 502, 503, 504):
+				wait = 2.0 * (attempt + 1)
+				log.warning("HTTP %s; retry in %.1fs", exc.code, wait)
+				time.sleep(wait)
+				continue
+			raise urllib.error.HTTPError(
+				url, exc.code, err_body, exc.headers, None
+			) from exc
+		except (
+			urllib.error.URLError,
+			TimeoutError,
+			http.client.IncompleteRead,
+			http.client.RemoteDisconnected,
+			ssl.SSLError,
+			ConnectionResetError,
+			BrokenPipeError,
+		) as exc:
+			last_error = exc
+			wait = 1.5 * (attempt + 1)
+			log.warning(
+				"transient network error (%s); retry in %.1fs",
+				type(exc).__name__,
+				wait,
+			)
+			time.sleep(wait)
+	assert last_error is not None
+	raise last_error
+
+
+def create_page(
+	token: str,
+	parent_id: str,
+	title: str,
+	*,
+	title_property: str,
+	parent_kind: str,
+) -> dict[str, str]:
+	"""Create a Notion page under a wiki data source or parent page.
+
+	Args:
+	    token: Notion bearer token.
+	    parent_id: Parent data-source, database, or page id.
+	    title: Page title (truncated to 2000 chars).
+	    title_property: Title property name on the parent schema.
+	    parent_kind: One of ``data_source``, ``database``, or ``page``.
+
+	Returns:
+	    Dict with ``id`` and ``url`` keys.
+	"""
+	if parent_kind == "data_source":
+		parent: dict = {"type": "data_source_id", "data_source_id": parent_id}
+	elif parent_kind == "database":
+		parent = {"type": "database_id", "database_id": parent_id}
+	else:
+		parent = {"page_id": parent_id}
+
+	# Wiki pages (including nested children) use the data-source title property.
+	prop_name = title_property or "title"
+	props = {
+		prop_name: {
+			"title": [{"type": "text", "text": {"content": title[:2000]}}],
+		}
+	}
+	try:
+		page = notion_request(
+			token, "POST", "pages", {"parent": parent, "properties": props}
+		)
+	except urllib.error.HTTPError as exc:
+		# Some parent page_id contexts only accept the generic "title" property.
+		if prop_name != "title" and "title" in str(exc):
+			props = {
+				"title": {
+					"title": [{"type": "text", "text": {"content": title[:2000]}}],
+				}
+			}
+			page = notion_request(
+				token, "POST", "pages", {"parent": parent, "properties": props}
+			)
+		else:
+			raise
+	return {"id": page["id"], "url": page.get("url", "")}
+
+
+def update_page_markdown(token: str, page_id: str, markdown: str) -> None:
+	"""Replace page content via the Notion markdown PATCH endpoint."""
+	notion_request(
+		token,
+		"PATCH",
+		f"pages/{page_id}/markdown",
+		{
+			"type": "replace_content",
+			"replace_content": {"new_str": markdown},
+		},
+		notion_version=NOTION_VERSION_MARKDOWN,
+	)
+
+
+@dataclass
+class TagsSchemaCache:
+	"""Cached multi_select options for a wiki tags property.
+
+	Args:
+	    data_source_id: Notion data source id (caller-supplied).
+	    property_name: Multi-select property name (default ``标签``).
+	"""
+
+	data_source_id: str
+	property_name: str = "标签"
+	option_names: set[str] = field(default_factory=set)
+	loaded: bool = False
+
+	def refresh(self, token: str) -> None:
+		"""Load current multi_select option names from the data source schema."""
+		ds = notion_request(token, "GET", f"data_sources/{self.data_source_id}")
+		prop = (ds.get("properties") or {}).get(self.property_name) or {}
+		if prop.get("type") != "multi_select":
+			raise RuntimeError(
+				f"Notion property {self.property_name!r} is not multi_select "
+				f"(got {prop.get('type')!r})"
+			)
+		options = (prop.get("multi_select") or {}).get("options") or []
+		self.option_names = {
+			str(o.get("name", "")).strip() for o in options if o.get("name")
+		}
+		self.loaded = True
+
+	def ensure_options(self, token: str, tags: list[str]) -> None:
+		"""Merge missing tag names into the data source schema (preserving existing)."""
+		if not tags:
+			return
+		if not self.loaded:
+			self.refresh(token)
+		missing = [t for t in tags if t not in self.option_names]
+		if not missing:
+			return
+
+		ds = notion_request(token, "GET", f"data_sources/{self.data_source_id}")
+		prop = (ds.get("properties") or {}).get(self.property_name) or {}
+		existing = (prop.get("multi_select") or {}).get("options") or []
+		# Keep id/name/color so Notion does not wipe prior options.
+		merged: list[dict] = []
+		seen: set[str] = set()
+		for opt in existing:
+			name = str(opt.get("name", "")).strip()
+			if not name or name in seen:
+				continue
+			entry: dict = {"id": opt["id"], "name": name}
+			if opt.get("color"):
+				entry["color"] = opt["color"]
+			merged.append(entry)
+			seen.add(name)
+		for name in tags:
+			if name not in seen:
+				merged.append({"name": name})
+				seen.add(name)
+
+		log.info(
+			"adding %d tag option(s) to schema: %s",
+			len(missing),
+			", ".join(missing),
+		)
+		notion_request(
+			token,
+			"PATCH",
+			f"data_sources/{self.data_source_id}",
+			{
+				"properties": {
+					self.property_name: {
+						"multi_select": {"options": merged},
+					}
+				}
+			},
+		)
+		self.option_names = seen
+		self.loaded = True
+
+
+def update_page_tags(
+	token: str,
+	page_id: str,
+	tags: list[str],
+	*,
+	property_name: str = "标签",
+	tags_cache: TagsSchemaCache | None = None,
+) -> list[str]:
+	"""Write frontmatter tags into a Notion multi_select property; return applied names.
+
+	Wiki quirk: assigning a multi_select name that is not yet in the data-source
+	schema returns HTTP 200 but leaves the property empty. Ensure options first.
+	"""
+	if tags_cache is not None:
+		tags_cache.ensure_options(token, tags)
+
+	page = notion_request(
+		token,
+		"PATCH",
+		f"pages/{page_id}",
+		{
+			"properties": {
+				property_name: {
+					"multi_select": [{"name": t} for t in tags],
+				}
+			}
+		},
+	)
+	prop = (page.get("properties") or {}).get(property_name) or {}
+	applied = [
+		str(o.get("name", "")).strip()
+		for o in (prop.get("multi_select") or [])
+		if o.get("name")
+	]
+	if set(applied) != set(tags):
+		raise RuntimeError(
+			f"tags write mismatch on {page_id}: wanted {tags}, got {applied}"
+		)
+	return applied
+
+
+def upload_local_file(token: str, path: Path, cache: dict[str, str]) -> str:
+	"""Upload a local file to Notion and return a ``file-upload://`` source URI."""
+	key = str(path.resolve())
+	if key in cache:
+		return cache[key]
+
+	suffix = path.suffix.lower()
+	filename = path.name
+	if suffix == ".awebp":
+		filename = path.stem + ".webp"
+		suffix = ".webp"
+
+	content_type = (
+		CONTENT_TYPES.get(suffix)
+		or mimetypes.guess_type(filename)[0]
+		or "application/octet-stream"
+	)
+	created = notion_request(
+		token,
+		"POST",
+		"file_uploads",
+		{"filename": filename, "content_type": content_type},
+	)
+	upload_id = created["id"]
+
+	boundary = f"----NotionBoundary{int(time.time() * 1000)}"
+	file_bytes = path.read_bytes()
+	body = (
+		(
+			f"--{boundary}\r\n"
+			f'Content-Disposition: form-data; name="file"; filename="{filename}"\r\n'
+			f"Content-Type: {content_type}\r\n\r\n"
+		).encode()
+		+ file_bytes
+		+ f"\r\n--{boundary}--\r\n".encode()
+	)
+
+	url = f"https://api.notion.com/v1/file_uploads/{upload_id}/send"
+	req = urllib.request.Request(
+		url,
+		data=body,
+		method="POST",
+		headers={
+			"Authorization": f"Bearer {token}",
+			"Notion-Version": NOTION_VERSION_PAGES,
+			"Content-Type": f"multipart/form-data; boundary={boundary}",
+		},
+	)
+	with urllib.request.urlopen(req, timeout=180) as resp:
+		json.loads(resp.read().decode("utf-8"))
+
+	source = f"file-upload://{upload_id}"
+	cache[key] = source
+	return source
+
+
+def iter_blocks(token: str, block_id: str) -> Iterator[dict[str, Any]]:
+	"""Recursively yield child blocks under ``block_id`` (depth-first)."""
+	cursor: str | None = None
+	while True:
+		path = f"blocks/{block_id}/children?page_size=100"
+		if cursor:
+			path += f"&start_cursor={cursor}"
+		data = notion_request(token, "GET", path)
+		for block in data.get("results", []):
+			yield block
+			btype = block.get("type")
+			if block.get("has_children") and btype not in (
+				"child_page",
+				"child_database",
+			):
+				yield from iter_blocks(token, block["id"])
+		if not data.get("has_more"):
+			break
+		cursor = data.get("next_cursor")
+
+
+def rich_text_plain(block: dict) -> str:
+	"""Concatenate plain_text from a block's rich_text array."""
+	btype = block.get("type")
+	payload = block.get(btype) or {}
+	parts = payload.get("rich_text") or []
+	return "".join(p.get("plain_text", "") for p in parts)
+
+
+def delete_block(token: str, block_id: str) -> None:
+	"""Delete (archive) a Notion block."""
+	notion_request(token, "DELETE", f"blocks/{block_id}")
+
+
+def insert_image_after(
+	token: str,
+	parent_id: str,
+	after_block_id: str,
+	upload_id: str,
+	caption: str = "",
+) -> None:
+	"""Insert an uploaded image block after ``after_block_id``."""
+	image: dict = {
+		"type": "file_upload",
+		"file_upload": {"id": upload_id},
+	}
+	if caption:
+		image["caption"] = [{"type": "text", "text": {"content": caption[:2000]}}]
+	notion_request(
+		token,
+		"PATCH",
+		f"blocks/{parent_id}/children",
+		{
+			"after": after_block_id,
+			"children": [
+				{
+					"object": "block",
+					"type": "image",
+					"image": image,
+				}
+			],
+		},
+	)
+
+
+def attach_placeholder_images(
+	token: str,
+	page_id: str,
+	image_paths: list[Path],
+) -> int:
+	"""Replace ``⟦LOCALIMG:N⟧`` placeholders with uploaded image blocks.
+
+	Returns:
+	    Number of images successfully attached.
+	"""
+	upload_cache: dict[str, str] = {}
+	attached = 0
+	placeholder_re = re.compile(r"^⟦LOCALIMG:(\d+)⟧$")
+
+	matches: list[tuple[dict, int]] = []
+	for block in iter_blocks(token, page_id):
+		if block.get("type") != "paragraph":
+			continue
+		text = rich_text_plain(block).strip()
+		m = placeholder_re.match(text)
+		if not m:
+			continue
+		matches.append((block, int(m.group(1))))
+
+	for block, idx in matches:
+		if idx < 0 or idx >= len(image_paths):
+			log.warning("placeholder index out of range: %s", idx)
+			continue
+		path = image_paths[idx]
+		source = upload_local_file(token, path, upload_cache)
+		upload_id = source.split("://", 1)[1]
+		parent = block.get("parent", {})
+		parent_id = parent.get("page_id") or parent.get("block_id") or page_id
+		insert_image_after(token, parent_id, block["id"], upload_id, caption=path.name)
+		delete_block(token, block["id"])
+		attached += 1
+		time.sleep(0.15)
+	return attached
+
+
+def page_title(page: dict, title_property: str = "页面") -> str:
+	"""Extract the title plain text from a Notion page object.
+
+	Args:
+	    page: Notion page JSON.
+	    title_property: Preferred title property name to try first.
+	"""
+	props = page.get("properties", {})
+	for key in (title_property, "页面", "title", "Title", "Name", "名称"):
+		prop = props.get(key)
+		if not prop or prop.get("type") != "title":
+			continue
+		parts = prop.get("title") or []
+		return "".join(t.get("plain_text", "") for t in parts)
+	for prop in props.values():
+		if prop.get("type") == "title":
+			parts = prop.get("title") or []
+			return "".join(t.get("plain_text", "") for t in parts)
+	return ""
+
+
+def list_wiki_pages(token: str, data_source_id: str) -> list[dict]:
+	"""Query all pages in a wiki data source (paginated)."""
+	pages: list[dict] = []
+	cursor: str | None = None
+	while True:
+		payload: dict = {"page_size": 100}
+		if cursor:
+			payload["start_cursor"] = cursor
+		data = notion_request(
+			token, "POST", f"data_sources/{data_source_id}/query", payload
+		)
+		pages.extend(data.get("results", []))
+		if not data.get("has_more"):
+			break
+		cursor = data.get("next_cursor")
+	return pages

--- a/src/mkdocs_note/utils/notion/convert.py
+++ b/src/mkdocs_note/utils/notion/convert.py
@@ -1,0 +1,585 @@
+"""Markdown / notebook → Notion Enhanced Markdown conversion.
+
+Pure conversion helpers with no network I/O. Callers pass ``docs_root`` for
+path resolution instead of relying on a global docs directory.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from mkdocs_note.utils.meta import extract_tags, parse_frontmatter
+from mkdocs_note.utils.tree import docs_rel, title_from_path
+
+# Re-export for callers that previously imported extract_tags from convert.
+__all__ = [
+	"ADMONITION_STYLES",
+	"ASSET_SUFFIXES",
+	"CONTENT_TYPES",
+	"convert_markdown_file",
+	"extract_tags",
+	"md_references_asset",
+	"page_has_local_images",
+]
+
+ADMONITION_STYLES: dict[str, tuple[str, str]] = {
+	"note": ("blue_bg", "✒️️"),
+	"abstract": ("gray_bg", "📋"),
+	"info": ("blue_bg", "ℹ️"),
+	"tip": ("yellow_bg", "💡"),
+	"success": ("green_bg", "✅"),
+	"question": ("purple_bg", "❓"),
+	"warning": ("orange_bg", "⚠️"),
+	"failure": ("red_bg", "❌"),
+	"danger": ("red_bg", "⛔"),
+	"bug": ("red_bg", "🐛"),
+	"example": ("gray_bg", "🧪"),
+	"quote": ("gray_bg", "💬"),
+	"important": ("orange_bg", "⚠️"),
+	"review": ("green_bg", "🔍"),
+}
+
+CONTENT_TYPES = {
+	".jpg": "image/jpeg",
+	".jpeg": "image/jpeg",
+	".png": "image/png",
+	".gif": "image/gif",
+	".webp": "image/webp",
+	".awebp": "image/webp",
+	".svg": "image/svg+xml",
+	".bmp": "image/bmp",
+	".tif": "image/tiff",
+	".tiff": "image/tiff",
+}
+
+ASSET_SUFFIXES = set(CONTENT_TYPES) | {".pdf", ".mp4", ".webm", ".svg"}
+
+
+def strip_duplicate_h1(title: str, body: str) -> str:
+	"""Remove a leading H1 that duplicates the page title."""
+	lines = body.splitlines()
+	if not lines:
+		return body
+	first = lines[0].strip()
+	if first.startswith("# "):
+		h1 = first[2:].strip()
+		if h1 == title or h1 in title or title in h1:
+			return "\n".join(lines[1:]).lstrip("\n")
+	return body
+
+
+def collect_indented_block(
+	lines: list[str], start: int, indent: int
+) -> tuple[list[str], int]:
+	"""Collect consecutive lines indented at least ``indent`` spaces."""
+	collected: list[str] = []
+	i = start
+	while i < len(lines):
+		line = lines[i]
+		if line.strip() == "":
+			collected.append("")
+			i += 1
+			continue
+		leading = len(line) - len(line.lstrip(" "))
+		# Also accept tabs as indent units (rare in these notes).
+		if leading < indent and not line.startswith("\t" * (indent // 4 or 1)):
+			# Allow tab-indented content roughly equivalent to spaces.
+			if line.startswith("\t"):
+				tab_count = len(line) - len(line.lstrip("\t"))
+				if tab_count * 4 < indent:
+					break
+				collected.append(line[tab_count:])
+				i += 1
+				continue
+			break
+		collected.append(line[indent:] if leading >= indent else line.lstrip(" "))
+		i += 1
+	return collected, i
+
+
+def notion_indent_block(text: str, tabs: int = 1) -> str:
+	"""Indent block children for Notion; keep blank lines indented so nesting holds."""
+	prefix = "\t" * tabs
+	out: list[str] = []
+	for line in text.splitlines():
+		if line.strip() == "":
+			out.append(f"{prefix}<empty-block/>")
+		else:
+			out.append(prefix + line)
+	return "\n".join(out)
+
+
+_ADMON_LINE_RE = re.compile(
+	r"^(?P<indent>[ \t]*)"
+	r"(?P<markers>[!?]{3})(?P<expanded>\+?)"
+	r"\s*(?P<type>\w+)"
+	r"(?P<rest>.*?)\s*$"
+)
+_ADMON_INLINE_RE = re.compile(r"\binline(?:\s+end)?\b", re.IGNORECASE)
+_ADMON_TITLE_RE = re.compile(r'"([^"]*)"')
+
+
+def _parse_admonition_rest(rest: str) -> tuple[str | None, bool]:
+	"""Parse optional inline flag + quoted title from the remainder of an admonition header."""
+	rest = rest.strip()
+	if not rest:
+		return None, False
+	inline = bool(_ADMON_INLINE_RE.search(rest))
+	# Strip inline markers before / after title.
+	cleaned = _ADMON_INLINE_RE.sub(" ", rest)
+	cleaned = re.sub(r"\s+", " ", cleaned).strip()
+	title_match = _ADMON_TITLE_RE.search(cleaned)
+	title = title_match.group(1) if title_match else None
+	return title, inline
+
+
+def convert_admonitions_and_tabs(text: str) -> str:
+	"""Convert Material admonitions and content tabs to Notion markup."""
+	lines = text.splitlines()
+	out: list[str] = []
+	i = 0
+	tab_re = re.compile(r'^([ \t]*)===\s+"([^"]+)"\s*$')
+
+	while i < len(lines):
+		line = lines[i]
+		ad_match = _ADMON_LINE_RE.match(line)
+		if ad_match:
+			indent_ws = ad_match.group("indent") or ""
+			indent = len(indent_ws.replace("\t", "    "))
+			markers = ad_match.group("markers")
+			ad_type = ad_match.group("type")
+			title, _inline = _parse_admonition_rest(ad_match.group("rest") or "")
+			# Material body is indented 4 spaces beyond the admonition marker line.
+			body_indent = indent + 4
+			block_lines, i = collect_indented_block(lines, i + 1, body_indent)
+			inner = convert_admonitions_and_tabs("\n".join(block_lines).strip("\n"))
+			if markers.startswith("?"):
+				summary = title or ad_type.capitalize()
+				block = (
+					f"<details>\n<summary>{summary}</summary>\n"
+					f"{notion_indent_block(inner)}\n</details>"
+				)
+			else:
+				color, icon = ADMONITION_STYLES.get(ad_type, ("gray_bg", "📌"))
+				# Inline admonitions have no Notion float equivalent → normal callout.
+				header = f"**{title}**\n" if title else ""
+				block = (
+					f'<callout icon="{icon}" color="{color}">\n'
+					f"{notion_indent_block(header + inner)}\n"
+					"</callout>"
+				)
+			out.append(block)
+			continue
+
+		tab_match = tab_re.match(line)
+		if tab_match:
+			label = tab_match.group(2)
+			indent_ws = tab_match.group(1) or ""
+			indent = len(indent_ws.replace("\t", "    "))
+			block_lines, i = collect_indented_block(lines, i + 1, indent + 4)
+			inner = convert_admonitions_and_tabs("\n".join(block_lines).strip("\n"))
+			out.append(f"### {label}")
+			out.append(inner)
+			continue
+
+		out.append(line)
+		i += 1
+
+	return "\n".join(out)
+
+
+def convert_inline_math(text: str) -> str:
+	"""Adapt KaTeX-style math delimiters for Notion."""
+
+	def repl_block(match: re.Match[str]) -> str:
+		return f"$`{match.group(1).strip()}`$"
+
+	text = re.sub(r"\$\$([\s\S]+?)\$\$", lambda m: f"$${m.group(1)}$$", text)
+	text = re.sub(r"(?<!\$)\$(?!\$)([^$\n]+?)\$(?!\$)", repl_block, text)
+	return text
+
+
+def convert_html_blocks(text: str) -> str:
+	"""Convert known HTML embeds and strip HTML comments."""
+	text = re.sub(
+		r'<div\s+class="responsive-video-container">\s*'
+		r'<iframe[^>]+src="([^"]+)"[^>]*>\s*</iframe>\s*</div>',
+		lambda m: f'<video src="{m.group(1)}">Video</video>',
+		text,
+		flags=re.IGNORECASE | re.DOTALL,
+	)
+	text = re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+	return text
+
+
+def resolve_local_asset_path(
+	raw: str, source_file: Path, docs_root: Path
+) -> Path | None:
+	"""Resolve a relative or site-absolute asset path under ``docs_root``."""
+	raw = raw.strip()
+	if not raw or raw.startswith(("http://", "https://")):
+		return None
+	if raw.startswith("/"):
+		candidate = (docs_root / raw.lstrip("/")).resolve()
+	else:
+		candidate = (source_file.parent / raw).resolve()
+	try:
+		candidate.relative_to(docs_root.resolve())
+	except ValueError:
+		return None
+	return candidate if candidate.exists() else None
+
+
+def resolve_image_url(
+	raw: str, source_file: Path, site_url: str, docs_root: Path
+) -> str:
+	"""Build an absolute site URL for an image reference."""
+	raw = raw.strip()
+	if raw.startswith(("http://", "https://")):
+		return raw
+	if raw.startswith("/"):
+		rel = docs_rel(raw.lstrip("/"))
+	else:
+		candidate = resolve_local_asset_path(raw, source_file, docs_root)
+		if candidate is not None:
+			rel = docs_rel(str(candidate.relative_to(docs_root)))
+		else:
+			rel = docs_rel(
+				str((source_file.parent / raw).resolve().relative_to(docs_root))
+			)
+	encoded = "/".join(quote(part, safe="") for part in rel.split("/"))
+	return f"{site_url.rstrip('/')}/{encoded}"
+
+
+def resolve_internal_target(raw: str, source_file: Path, docs_root: Path) -> str:
+	"""Resolve an internal markdown link to a docs-relative path."""
+	target = raw.split("#", 1)[0].strip()
+	if not target:
+		return ""
+	if target.startswith("/"):
+		resolved = (docs_root / target.lstrip("/")).resolve()
+	else:
+		resolved = (source_file.parent / target).resolve()
+	try:
+		rel = docs_rel(str(resolved.relative_to(docs_root)))
+	except ValueError:
+		return target
+	if rel.endswith(".ipynb"):
+		rel = rel[:-6] + ".md"
+	return rel
+
+
+def convert_images(
+	text: str,
+	source_file: Path,
+	site_url: str,
+	docs_root: Path,
+	upload_local: Callable[[Path], Any] | None = None,
+) -> str:
+	"""Rewrite image markdown; optionally upload local files via ``upload_local``."""
+
+	def repl(match: re.Match[str]) -> str:
+		alt = match.group(1) or ""
+		src = match.group(2).strip()
+		if upload_local is not None and not src.startswith(("http://", "https://")):
+			local = resolve_local_asset_path(src, source_file, docs_root)
+			if local is not None:
+				uploaded = upload_local(local)
+				if uploaded:
+					if str(uploaded).startswith("file-upload://"):
+						return f'<image src="{uploaded}">{alt}</image>'
+					return f"\n\n{uploaded}\n\n"
+		url = resolve_image_url(src, source_file, site_url, docs_root)
+		return f"![{alt}]({url})"
+
+	return re.sub(r"!\[([^\]]*)\]\(([^)]+)\)", repl, text)
+
+
+def convert_links(
+	text: str,
+	source_file: Path,
+	page_map: dict[str, dict[str, str]],
+	docs_root: Path,
+) -> str:
+	"""Rewrite internal links to Notion ``mention-page`` when mapped."""
+
+	def repl(match: re.Match[str]) -> str:
+		label = match.group(1)
+		raw = match.group(2)
+		if raw.startswith(("http://", "https://")):
+			return match.group(0)
+		anchor = ""
+		if "#" in raw:
+			path_part, anchor = raw.split("#", 1)
+		else:
+			path_part = raw
+		if not path_part:
+			return match.group(0)
+		rel = resolve_internal_target(path_part, source_file, docs_root)
+		if rel in page_map and page_map[rel].get("url"):
+			url = page_map[rel]["url"]
+			if anchor:
+				url = f"{url}#{anchor}"
+			return f'<mention-page url="{url}">{label}</mention-page>'
+		return f"[{label}]({raw})"
+
+	return re.sub(r"\[([^\]]+)\]\(([^)]+)\)", repl, text)
+
+
+def ipynb_to_markdown(path: Path) -> tuple[dict[str, Any], str]:
+	"""Convert a Jupyter notebook to markdown (cells only; no raw JSON)."""
+	data = json.loads(path.read_text(encoding="utf-8"))
+	meta: dict[str, Any] = {}
+	nb_meta = data.get("metadata") or {}
+	# Prefer explicit title from notebook metadata when present.
+	if isinstance(nb_meta.get("title"), str):
+		meta["title"] = nb_meta["title"]
+
+	parts: list[str] = []
+	for cell in data.get("cells") or []:
+		ctype = cell.get("cell_type")
+		source = cell.get("source") or []
+		if isinstance(source, list):
+			text = "".join(source)
+		else:
+			text = str(source)
+		text = text.rstrip("\n")
+		if not text.strip():
+			continue
+		if ctype == "markdown":
+			parts.append(text)
+		elif ctype == "code":
+			lang = ""
+			kernelspec = nb_meta.get("kernelspec") or {}
+			language = kernelspec.get("language") or ""
+			if language:
+				lang = str(language)
+			else:
+				lang = "python"
+			parts.append(f"```{lang}\n{text}\n```")
+			# Include plain-text / stream outputs when useful.
+			outputs = cell.get("outputs") or []
+			out_chunks: list[str] = []
+			for out in outputs:
+				otype = out.get("output_type")
+				if otype == "stream":
+					text_out = out.get("text") or ""
+					if isinstance(text_out, list):
+						text_out = "".join(text_out)
+					if str(text_out).strip():
+						out_chunks.append(str(text_out).rstrip())
+				elif otype in ("execute_result", "display_data"):
+					data_out = out.get("data") or {}
+					if "text/plain" in data_out:
+						plain = data_out["text/plain"]
+						if isinstance(plain, list):
+							plain = "".join(plain)
+						if str(plain).strip():
+							out_chunks.append(str(plain).rstrip())
+					elif "text/markdown" in data_out:
+						md = data_out["text/markdown"]
+						if isinstance(md, list):
+							md = "".join(md)
+						if str(md).strip():
+							out_chunks.append(str(md).rstrip())
+			if out_chunks:
+				parts.append("```\n" + "\n".join(out_chunks) + "\n```")
+		# skip raw cells
+	body = "\n\n".join(parts).strip() + "\n"
+	return meta, body
+
+
+def normalize_blockquotes_for_notion(text: str) -> str:
+	"""Drop MkDocs blank quote markers (`>` alone) and collapse quote runs for Notion.
+
+	In MkDocs/Material, a lone `>` between quote lines acts as a paragraph/line break
+	and does not render as an empty citation. Notion treats that line as an empty
+	quote block. Convert each contiguous `>` run into a single Notion multi-line
+	quote using ``<br>``, omitting blank quote lines.
+	"""
+	lines = text.splitlines()
+	out: list[str] = []
+	i = 0
+	quote_re = re.compile(r"^([ \t]*)>([ \t]?)(.*)$")
+	fence_re = re.compile(r"^([ \t]*)(`{3,}|~{3,})(.*)$")
+
+	while i < len(lines):
+		line = lines[i]
+		fence = fence_re.match(line)
+		if fence:
+			marker = fence.group(2)
+			ch = marker[0]
+			n = len(marker)
+			out.append(line)
+			i += 1
+			while i < len(lines):
+				out.append(lines[i])
+				close = fence_re.match(lines[i])
+				if (
+					close
+					and close.group(2)[0] == ch
+					and len(close.group(2)) >= n
+					and close.group(3).strip() == ""
+				):
+					i += 1
+					break
+				i += 1
+			continue
+
+		m = quote_re.match(line)
+		if not m:
+			out.append(line)
+			i += 1
+			continue
+
+		indent = m.group(1)
+		parts: list[str] = []
+		while i < len(lines):
+			qm = quote_re.match(lines[i])
+			if not qm or qm.group(1) != indent:
+				break
+			body = qm.group(3)
+			# Lone `>` / `> ` → MkDocs line break; skip for Notion.
+			if body.strip() == "":
+				i += 1
+				continue
+			parts.append(body)
+			i += 1
+
+		if not parts:
+			continue
+		# Notion multi-line quote: one `>` line with <br> separators.
+		out.append(f"{indent}> {'<br>'.join(parts)}")
+
+	return "\n".join(out)
+
+
+_TABLE_SEP_CELL_RE = re.compile(r"^:?-+:?$")
+_FENCE_LINE_RE = re.compile(r"^([ \t]*)(`{3,}|~{3,})(.*)$")
+
+
+def is_gfm_table_separator_row(line: str) -> bool:
+	"""True for GFM alignment rows like ``|:-:|``, ``|:-|``, ``|-:|``, ``| --- | :---: |``."""
+	s = line.strip()
+	if "|" not in s:
+		return False
+	core = s.removeprefix("|")
+	core = core.removesuffix("|")
+	cells = core.split("|")
+	if not cells:
+		return False
+	for cell in cells:
+		if not _TABLE_SEP_CELL_RE.fullmatch(cell.strip()):
+			return False
+	return True
+
+
+def strip_gfm_table_separators(text: str) -> str:
+	"""Drop GFM table alignment rows so Notion does not insert them as data rows.
+
+	Markdown renderers ignore ``|:-:|`` / ``|:-|`` / ``|-:|`` separator lines; Notion's
+	markdown ingest treats them as ordinary table rows.
+	"""
+	lines = text.splitlines()
+	out: list[str] = []
+	i = 0
+	while i < len(lines):
+		line = lines[i]
+		fence = _FENCE_LINE_RE.match(line)
+		if fence:
+			marker = fence.group(2)
+			ch = marker[0]
+			n = len(marker)
+			out.append(line)
+			i += 1
+			while i < len(lines):
+				out.append(lines[i])
+				close = _FENCE_LINE_RE.match(lines[i])
+				if (
+					close
+					and close.group(2)[0] == ch
+					and len(close.group(2)) >= n
+					and close.group(3).strip() == ""
+				):
+					i += 1
+					break
+				i += 1
+			continue
+		if is_gfm_table_separator_row(line):
+			i += 1
+			continue
+		out.append(line)
+		i += 1
+	return "\n".join(out)
+
+
+def convert_markdown_file(
+	file_path: Path,
+	site_url: str,
+	page_map: dict[str, dict[str, str]],
+	docs_root: Path,
+	upload_local: Callable[[Path], Any] | None = None,
+) -> tuple[str, str, dict[str, Any]]:
+	"""Convert a markdown or notebook file to Notion-ready markdown.
+
+	Args:
+	    file_path: Source ``.md`` or ``.ipynb`` path.
+	    site_url: Public site base URL for absolute image links.
+	    page_map: Docs-relative path → ``{"id", "url"}`` for mention links.
+	    docs_root: Documentation root used for path resolution.
+	    upload_local: Optional callback that accepts a local ``Path`` and returns
+	        an upload token / placeholder string.
+
+	Returns:
+	    Tuple of ``(title, body, frontmatter_meta)``.
+	"""
+	if file_path.suffix.lower() == ".ipynb":
+		meta, body = ipynb_to_markdown(file_path)
+		title = str(meta.get("title") or title_from_path(file_path)).strip()
+	else:
+		raw = file_path.read_text(encoding="utf-8")
+		meta, body = parse_frontmatter(raw)
+		title = str(meta.get("title") or title_from_path(file_path)).strip()
+		body = strip_duplicate_h1(title, body)
+
+	body = convert_html_blocks(body)
+	body = normalize_blockquotes_for_notion(body)
+	body = convert_admonitions_and_tabs(body)
+	body = convert_inline_math(body)
+	body = convert_images(
+		body, file_path, site_url, docs_root, upload_local=upload_local
+	)
+	body = convert_links(body, file_path, page_map, docs_root)
+	body = strip_gfm_table_separators(body)
+	body = re.sub(r"\n{3,}", "\n\n", body).strip()
+	return title, body, meta
+
+
+def page_has_local_images(source: Path) -> bool:
+	"""Return True if the file contains any non-http(s) image references."""
+	text = source.read_text(encoding="utf-8", errors="ignore")
+	for _, src in re.findall(r"!\[([^\]]*)\]\(([^)]+)\)", text):
+		raw = src.strip()
+		if not raw.startswith(("http://", "https://")):
+			return True
+	return False
+
+
+def md_references_asset(source: Path, asset_rel: str, docs_root: Path) -> bool:
+	"""Cheap check: whether markdown likely references a docs-relative asset."""
+	text = source.read_text(encoding="utf-8", errors="ignore")
+	name = Path(asset_rel).name
+	if name not in text:
+		return False
+	for _, src in re.findall(r"!\[([^\]]*)\]\(([^)]+)\)", text):
+		local = resolve_local_asset_path(src.strip(), source, docs_root)
+		if local is None:
+			continue
+		if docs_rel(str(local.relative_to(docs_root))) == asset_rel:
+			return True
+	return False

--- a/src/mkdocs_note/utils/notion/sync.py
+++ b/src/mkdocs_note/utils/notion/sync.py
@@ -1,0 +1,984 @@
+"""Notion wiki sync orchestration.
+
+Token resolution, git incremental diff, page-map state, section ensure, and
+``run_sync`` — the CLI entrypoint. Wiki IDs and site URL come from
+``SyncOptions`` (or env fallbacks); nothing is hardcoded here.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from mkdocs_note.utils.meta import extract_tags
+from mkdocs_note.utils.notion.client import (
+	TagsSchemaCache,
+	attach_placeholder_images,
+	create_page,
+	list_wiki_pages,
+	page_title,
+	update_page_markdown,
+	update_page_tags,
+)
+from mkdocs_note.utils.notion.convert import (
+	ASSET_SUFFIXES,
+	convert_markdown_file,
+	md_references_asset,
+)
+from mkdocs_note.utils.tree import (
+	TreeNode,
+	build_page_tree,
+	docs_rel,
+	index_tree,
+	is_index_doc,
+)
+
+# Alias for callers / docs that speak in nav terms.
+NavItem = TreeNode
+
+log = logging.getLogger("mkdocs_note.notion")
+
+
+# ---------------------------------------------------------------------------
+# Options & state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SyncOptions:
+	"""Configuration for a Notion sync run (assembled by CLI / mkdocs.yml)."""
+
+	project_root: Path
+	docs_dir: Path
+	notes_root: Path
+	nav_file: Path | None
+	database_id: str
+	data_source_id: str
+	site_url: str
+	state_path: Path
+	delay: float
+	title_property: str = "页面"
+	tags_property: str = "标签"
+	token: str | None = None
+	allow_cursor_mcp_token: bool = False
+	silence_mcp_token_warning: bool = False
+	full: bool = False
+	base: str | None = None
+	paths: list[str] | None = None
+	paths_file: Path | None = None
+	section: list[str] | None = None
+	rebuild_state: bool = False
+	no_images: bool = False
+	dry_run: bool = False
+	continue_on_error: bool = False
+	verbose: bool = False
+
+
+@dataclass
+class MigrationState:
+	"""Local map of docs-relative keys → Notion page id/url."""
+
+	root_page_id: str = ""
+	data_source_id: str = ""
+	title_property: str = "页面"
+	pages: dict[str, dict[str, str]] = field(default_factory=dict)
+
+
+@dataclass
+class DiffSet:
+	"""Incremental change set relative to ``docs_dir``."""
+
+	md_changed: set[str] = field(default_factory=set)
+	md_deleted: set[str] = field(default_factory=set)
+	assets_changed: set[str] = field(default_factory=set)
+	nav_changed: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Logging & token
+# ---------------------------------------------------------------------------
+
+
+def setup_logging(verbose: bool = False) -> None:
+	"""Configure root logging for CLI runs (stdout, no log files)."""
+	level = logging.DEBUG if verbose else logging.INFO
+	handler = logging.StreamHandler(sys.stdout)
+	handler.setFormatter(logging.Formatter("%(levelname)s %(message)s"))
+	root = logging.getLogger()
+	root.handlers.clear()
+	root.addHandler(handler)
+	root.setLevel(level)
+	logging.getLogger("urllib3").setLevel(logging.WARNING)
+
+
+def _load_dotenv(path: Path) -> None:
+	"""Load KEY=VALUE lines into os.environ without overriding existing vars."""
+	if not path.is_file():
+		return
+	for raw in path.read_text(encoding="utf-8").splitlines():
+		line = raw.strip()
+		if not line or line.startswith("#") or "=" not in line:
+			continue
+		key, _, value = line.partition("=")
+		key = key.strip()
+		value = value.strip().strip("'").strip('"')
+		if key and key not in os.environ:
+			os.environ[key] = value
+
+
+def _token_from_cursor_mcp() -> str | None:
+	"""Reuse Notion token already configured for Cursor MCP (local dev)."""
+	mcp_path = Path.home() / ".cursor" / "mcp.json"
+	if not mcp_path.is_file():
+		return None
+	try:
+		data = json.loads(mcp_path.read_text(encoding="utf-8"))
+	except (OSError, json.JSONDecodeError):
+		return None
+	servers = data.get("mcpServers") or {}
+	for name in ("notionApi", "Notion", "notion"):
+		env = (servers.get(name) or {}).get("env") or {}
+		for key in ("NOTION_TOKEN", "NOTION_API_KEY"):
+			val = env.get(key)
+			if val:
+				return str(val).strip()
+	for cfg in servers.values():
+		env = (cfg or {}).get("env") or {}
+		for key in ("NOTION_TOKEN", "NOTION_API_KEY"):
+			val = env.get(key)
+			if val:
+				return str(val).strip()
+	return None
+
+
+def resolve_token(
+	explicit: str | None,
+	project_root: Path,
+	allow_cursor_mcp_token: bool = False,
+	silence_mcp_token_warning: bool = False,
+) -> str | None:
+	"""Resolve Notion token without requiring ``--token`` every run.
+
+	Order: explicit → load ``.env`` from *project_root* (no override) →
+	``NOTION_TOKEN`` / ``NOTION_API_KEY`` → ``project_root/.notion_token`` →
+	``~/.config/notion/token`` → (only if *allow_cursor_mcp_token*) Cursor
+	``mcp.json``.
+	"""
+	if explicit and explicit.strip():
+		return explicit.strip()
+
+	_load_dotenv(Path(project_root) / ".env")
+	for key in ("NOTION_TOKEN", "NOTION_API_KEY"):
+		val = os.environ.get(key)
+		if val and val.strip():
+			return val.strip()
+
+	for path in (
+		Path(project_root) / ".notion_token",
+		Path.home() / ".config" / "notion" / "token",
+	):
+		if path.is_file():
+			val = path.read_text(encoding="utf-8").strip()
+			if val:
+				return val
+
+	if allow_cursor_mcp_token:
+		token = _token_from_cursor_mcp()
+		if token:
+			if not silence_mcp_token_warning:
+				log.warning(
+					"Notion token loaded from Cursor MCP config "
+					"(~/.cursor/mcp.json). This is not recommended unless you "
+					"are a developer or have special needs. Set "
+					"silence_mcp_token_warning: true to disable this warning."
+				)
+			return token
+	return None
+
+
+# ---------------------------------------------------------------------------
+# Config / path helpers
+# ---------------------------------------------------------------------------
+
+
+def _docs_prefix(project_root: Path, docs_dir: Path) -> str:
+	"""Repo-relative docs prefix with trailing slash (e.g. ``docs/``)."""
+	root = Path(project_root).resolve()
+	docs = Path(docs_dir).resolve()
+	try:
+		rel = docs.relative_to(root)
+		return docs_rel(str(rel)).rstrip("/") + "/"
+	except ValueError:
+		return docs_rel(docs.name).rstrip("/") + "/"
+
+
+def _apply_env_overrides(options: SyncOptions) -> SyncOptions:
+	"""Fill empty option fields from environment variables."""
+	database_id = (
+		options.database_id or os.environ.get("NOTION_WIKI_DATABASE") or ""
+	).strip()
+	data_source_id = (
+		options.data_source_id or os.environ.get("NOTION_WIKI_DATA_SOURCE") or ""
+	).strip()
+	title_property = (
+		options.title_property or os.environ.get("NOTION_TITLE_PROPERTY") or "页面"
+	).strip()
+	tags_property = (
+		options.tags_property or os.environ.get("NOTION_TAGS_PROPERTY") or "标签"
+	).strip()
+	state_raw = str(options.state_path) if options.state_path else ""
+	if not state_raw.strip():
+		state_raw = os.environ.get("NOTION_STATE_PATH") or ".notion_sync_state.json"
+	state_path = Path(state_raw)
+	if not state_path.is_absolute():
+		state_path = Path(options.project_root) / state_path
+
+	return SyncOptions(
+		project_root=Path(options.project_root),
+		docs_dir=Path(options.docs_dir),
+		notes_root=Path(options.notes_root),
+		nav_file=Path(options.nav_file) if options.nav_file else None,
+		database_id=database_id,
+		data_source_id=data_source_id,
+		site_url=(options.site_url or "").rstrip("/"),
+		state_path=state_path,
+		delay=options.delay,
+		title_property=title_property,
+		tags_property=tags_property,
+		token=options.token,
+		allow_cursor_mcp_token=options.allow_cursor_mcp_token,
+		silence_mcp_token_warning=options.silence_mcp_token_warning,
+		full=options.full,
+		base=options.base,
+		paths=options.paths,
+		paths_file=options.paths_file,
+		section=options.section,
+		rebuild_state=options.rebuild_state,
+		no_images=options.no_images,
+		dry_run=options.dry_run,
+		continue_on_error=options.continue_on_error,
+		verbose=options.verbose,
+	)
+
+
+def _strip_docs_prefix(path: str, docs_prefix: str) -> str:
+	"""Normalize a path to docs-relative (strip configured or bare ``docs/``)."""
+	rel = docs_rel(path)
+	if rel.startswith(docs_prefix):
+		return rel[len(docs_prefix) :]
+	if docs_prefix != "docs/" and rel.startswith("docs/"):
+		return rel[5:]
+	return rel
+
+
+# ---------------------------------------------------------------------------
+# State persistence
+# ---------------------------------------------------------------------------
+
+
+def load_state(path: Path, default_title: str = "页面") -> MigrationState:
+	"""Load migration state JSON, or return an empty state."""
+	if not path.exists():
+		return MigrationState(title_property=default_title)
+	data = json.loads(path.read_text(encoding="utf-8"))
+	return MigrationState(
+		root_page_id=data.get("root_page_id", ""),
+		data_source_id=data.get("data_source_id", ""),
+		title_property=data.get("title_property", default_title),
+		pages=data.get("pages", {}),
+	)
+
+
+def save_state(path: Path, state: MigrationState) -> None:
+	"""Persist migration state JSON."""
+	path.parent.mkdir(parents=True, exist_ok=True)
+	path.write_text(
+		json.dumps(
+			{
+				"root_page_id": state.root_page_id,
+				"data_source_id": state.data_source_id,
+				"title_property": state.title_property,
+				"pages": state.pages,
+			},
+			ensure_ascii=False,
+			indent=2,
+		),
+		encoding="utf-8",
+	)
+
+
+def rebuild_state_from_wiki(
+	token: str,
+	*,
+	data_source_id: str,
+	database_id: str,
+	title_property: str = "页面",
+	tree: list[TreeNode] | None = None,
+	nav_file: Path | None = None,
+	notes_root: Path | None = None,
+	docs_dir: Path | None = None,
+	sections: list[str] | None = None,
+) -> MigrationState:
+	"""Match existing wiki pages to nav / directory tree keys (recovery).
+
+	Pass *tree* when already built; otherwise call ``build_page_tree`` using
+	*nav_file* / *notes_root* / *docs_dir*.
+	"""
+	state = MigrationState(
+		root_page_id=database_id,
+		data_source_id=data_source_id,
+		title_property=title_property,
+	)
+	pages = list_wiki_pages(token, data_source_id)
+	log.info("fetched %d pages from wiki for state rebuild", len(pages))
+
+	by_parent: dict[str, list[dict[str, str]]] = {}
+	for page in pages:
+		title = page_title(page, title_property=title_property)
+		parent = page.get("parent", {})
+		if parent.get("type") == "page_id":
+			parent_key = parent["page_id"]
+		elif parent.get("type") == "database_id":
+			parent_key = parent["database_id"]
+		elif parent.get("type") == "data_source_id":
+			parent_key = parent["data_source_id"]
+		else:
+			parent_key = database_id
+		by_parent.setdefault(parent_key, []).append(
+			{
+				"id": page["id"],
+				"title": title,
+				"url": page.get(
+					"url",
+					f"https://www.notion.so/{page['id'].replace('-', '')}",
+				),
+			}
+		)
+
+	if tree is None:
+		if notes_root is None or docs_dir is None:
+			raise ValueError(
+				"rebuild_state_from_wiki requires tree=… or notes_root=… and docs_dir=…"
+			)
+		tree, source = build_page_tree(
+			nav_file=nav_file, notes_root=notes_root, docs_dir=docs_dir
+		)
+		log.info("page tree source for rebuild: %s", source)
+
+	notebook = next((item for item in tree if item.title == "Notebook"), None)
+	start_items = notebook.children if notebook else tree
+	if notebook:
+		state.pages[notebook.key] = {
+			"id": database_id,
+			"url": f"https://www.notion.so/{database_id.replace('-', '')}",
+		}
+
+	def section_allowed(item: NavItem) -> bool:
+		if not sections:
+			return True
+		if item.file_rel:
+			return any(item.file_rel.startswith(s) for s in sections)
+		return any(section_allowed(c) for c in item.children)
+
+	def match_items(items: list[NavItem], parent_page_id: str) -> None:
+		unused = list(by_parent.get(parent_page_id, []))
+		for item in items:
+			if not section_allowed(item):
+				continue
+			match = next((c for c in unused if c["title"] == item.title), None)
+			if match is None:
+				log.warning("missing Notion page for %r title=%r", item.key, item.title)
+				continue
+			unused.remove(match)
+			state.pages[item.key] = {"id": match["id"], "url": match["url"]}
+			if item.children:
+				match_items(item.children, match["id"])
+
+	match_items(start_items, database_id)
+	if data_source_id != database_id:
+		match_items(
+			[i for i in start_items if i.key not in state.pages],
+			data_source_id,
+		)
+	return state
+
+
+# ---------------------------------------------------------------------------
+# Git diff (incremental)
+# ---------------------------------------------------------------------------
+
+
+def _run_git(project_root: Path, *args: str) -> str:
+	"""Run git with *project_root* as cwd; disable quotepath for UTF-8 paths."""
+	# core.quotepath=false: non-ASCII paths must be raw UTF-8. Default quoting
+	# emits `"docs/...\350\256..."` which fails prefix checks and empties the
+	# incremental diff for almost all Chinese note paths.
+	result = subprocess.run(
+		["git", "-c", "core.quotepath=false", *args],
+		cwd=project_root,
+		check=False,
+		capture_output=True,
+		text=True,
+	)
+	if result.returncode != 0:
+		raise RuntimeError(
+			f"git {' '.join(args)} failed ({result.returncode}): "
+			f"{result.stderr.strip()}"
+		)
+	return result.stdout
+
+
+def resolve_git_base(project_root: Path, explicit: str | None) -> str | None:
+	"""Pick a base ref for incremental sync.
+
+	Priority: explicit → ``GITHUB_EVENT_BEFORE`` → ``NOTION_SYNC_BASE`` →
+	``HEAD~1``. Returns ``None`` when a full sync is required.
+	"""
+	if explicit:
+		if explicit in ("", "0" * 40, "full"):
+			return None
+		return explicit
+
+	before = os.environ.get("GITHUB_EVENT_BEFORE") or os.environ.get("NOTION_SYNC_BASE")
+	if before:
+		if before in ("", "0" * 40):
+			return None
+		return before
+
+	try:
+		_run_git(project_root, "rev-parse", "--verify", "HEAD~1")
+		return "HEAD~1"
+	except RuntimeError:
+		return None
+
+
+def git_diff(
+	base: str | None,
+	project_root: Path,
+	docs_dir: Path,
+) -> DiffSet:
+	"""Collect docs changes between ``base...HEAD``. If *base* is None → full."""
+	if base is None:
+		# Caller will expand to all pages when nav_changed + full mode.
+		return DiffSet(nav_changed=True)
+
+	docs_prefix = _docs_prefix(project_root, docs_dir)
+	pathspec = docs_prefix.rstrip("/")
+	out = _run_git(
+		project_root,
+		"diff",
+		"--name-status",
+		"--find-renames",
+		f"{base}...HEAD",
+		"--",
+		pathspec,
+	)
+	diff = DiffSet()
+	for line in out.splitlines():
+		if not line.strip():
+			continue
+		parts = line.split("\t")
+		status = parts[0]
+		paths = parts[1:]
+		# Renames: R100\told\tnew
+		if status.startswith("R") and len(paths) == 2:
+			old, new = paths
+			_classify_path(diff, old, docs_prefix, deleted=True)
+			_classify_path(diff, new, docs_prefix, deleted=False)
+			continue
+		path = paths[0]
+		deleted = status.startswith("D")
+		_classify_path(diff, path, docs_prefix, deleted=deleted)
+	return diff
+
+
+def _classify_path(
+	diff: DiffSet,
+	path: str,
+	docs_prefix: str,
+	*,
+	deleted: bool,
+) -> None:
+	"""Classify a repo-relative path into the diff set."""
+	path = docs_rel(path)
+	if path == f"{docs_prefix}.nav.yml" or path.endswith("/.nav.yml"):
+		diff.nav_changed = True
+		return
+	if not path.startswith(docs_prefix):
+		return
+	rel = path[len(docs_prefix) :]
+	suffix = Path(rel).suffix.lower()
+	if suffix in (".md", ".ipynb"):
+		if deleted:
+			diff.md_deleted.add(rel)
+		else:
+			diff.md_changed.add(rel)
+	elif suffix in ASSET_SUFFIXES and not deleted:
+		diff.assets_changed.add(rel)
+
+
+def expand_asset_dependents(
+	assets: set[str],
+	nav_index: dict[str, NavItem],
+	docs_dir: Path,
+	sections: list[str] | None,
+) -> set[str]:
+	"""Find nav-listed markdown files that reference changed assets (scoped)."""
+	if not assets:
+		return set()
+	candidates: list[Path] = []
+	for item in nav_index.values():
+		if not item.file_rel or is_index_doc(item.file_rel):
+			continue
+		if sections and not any(item.file_rel.startswith(s) for s in sections):
+			continue
+		source = docs_dir / item.file_rel
+		if source.exists():
+			candidates.append(source)
+
+	affected: set[str] = set()
+	for source in candidates:
+		rel = docs_rel(str(source.relative_to(docs_dir)))
+		for asset in assets:
+			if md_references_asset(source, asset, docs_dir):
+				affected.add(rel)
+				break
+	return affected
+
+
+# ---------------------------------------------------------------------------
+# Sync orchestration
+# ---------------------------------------------------------------------------
+
+
+def filter_sections(rel: str, sections: list[str] | None) -> bool:
+	"""True if *rel* is under any of the section prefixes (or no filter)."""
+	if not sections:
+		return True
+	return any(rel.startswith(s) for s in sections)
+
+
+def ensure_section(
+	token: str,
+	state: MigrationState,
+	state_path: Path,
+	nav_index: dict[str, NavItem],
+	key: str,
+	delay: float,
+	dry_run: bool,
+) -> str:
+	"""Ensure a section (or Notebook root) exists; return Notion page id."""
+	if key in state.pages:
+		return state.pages[key]["id"]
+
+	item = nav_index.get(key)
+	if item is None:
+		raise KeyError(f"nav key not found: {key}")
+
+	# Notebook root maps to the wiki database itself.
+	if item.title == "Notebook" and not item.parent_key:
+		state.pages[key] = {
+			"id": state.root_page_id,
+			"url": f"https://www.notion.so/{state.root_page_id.replace('-', '')}",
+		}
+		if not dry_run:
+			save_state(state_path, state)
+		return state.root_page_id
+
+	if item.parent_key:
+		parent_id = ensure_section(
+			token, state, state_path, nav_index, item.parent_key, delay, dry_run
+		)
+		parent_kind = "page"
+	else:
+		parent_id = state.data_source_id or state.root_page_id
+		parent_kind = "data_source" if state.data_source_id else "database"
+
+	log.info("create section %s (%s)", item.title, key)
+	if dry_run:
+		fake = f"dry-run-{key}"
+		state.pages[key] = {"id": fake, "url": f"https://www.notion.so/{fake}"}
+		return fake
+
+	info = create_page(
+		token,
+		parent_id,
+		item.title,
+		title_property=state.title_property,
+		parent_kind=parent_kind,
+	)
+	state.pages[key] = info
+	save_state(state_path, state)
+	time.sleep(delay)
+	return info["id"]
+
+
+def resolve_parent_id(
+	token: str,
+	state: MigrationState,
+	state_path: Path,
+	nav_index: dict[str, NavItem],
+	parent_key: str,
+	delay: float,
+	dry_run: bool,
+) -> tuple[str, str]:
+	"""Resolve parent Notion id and kind for a content page."""
+	if not parent_key:
+		parent_id = state.data_source_id or state.root_page_id
+		kind = "data_source" if state.data_source_id else "database"
+		return parent_id, kind
+	# Notebook root → wiki database / data source for children.
+	parent_item = nav_index.get(parent_key)
+	if parent_item and parent_item.title == "Notebook" and not parent_item.parent_key:
+		state.pages.setdefault(
+			parent_key,
+			{
+				"id": state.root_page_id,
+				"url": (f"https://www.notion.so/{state.root_page_id.replace('-', '')}"),
+			},
+		)
+		parent_id = state.data_source_id or state.root_page_id
+		kind = "data_source" if state.data_source_id else "database"
+		return parent_id, kind
+	page_id = ensure_section(
+		token, state, state_path, nav_index, parent_key, delay, dry_run
+	)
+	return page_id, "page"
+
+
+def sync_one_page(
+	token: str,
+	state: MigrationState,
+	state_path: Path,
+	nav_index: dict[str, NavItem],
+	item: NavItem,
+	*,
+	docs_dir: Path,
+	site_url: str,
+	delay: float,
+	dry_run: bool,
+	upload_images: bool,
+	tags_property: str = "标签",
+	tags_cache: TagsSchemaCache | None = None,
+) -> str:
+	"""Create or update one Notion page from a nav tree leaf."""
+	assert item.file_rel
+	source = docs_dir / item.file_rel
+	if not source.exists():
+		log.warning("skip missing file %s", item.file_rel)
+		return "missing"
+
+	parent_id, parent_kind = resolve_parent_id(
+		token,
+		state,
+		state_path,
+		nav_index,
+		item.parent_key,
+		delay,
+		dry_run,
+	)
+
+	created = item.file_rel not in state.pages
+	if created:
+		log.info("create page %s", item.file_rel)
+		if dry_run:
+			state.pages[item.file_rel] = {
+				"id": f"dry-run-{item.file_rel}",
+				"url": "https://www.notion.so/dry-run",
+			}
+		else:
+			info = create_page(
+				token,
+				parent_id,
+				item.title,
+				title_property=state.title_property,
+				parent_kind=parent_kind,
+			)
+			state.pages[item.file_rel] = info
+			save_state(state_path, state)
+			time.sleep(delay)
+	else:
+		log.info("update page %s", item.file_rel)
+
+	image_paths: list[Path] = []
+
+	def upload_local(path: Path) -> str:
+		if not upload_images:
+			return ""
+		image_paths.append(path)
+		return f"⟦LOCALIMG:{len(image_paths) - 1}⟧"
+
+	title_conv, content, meta = convert_markdown_file(
+		source,
+		site_url,
+		state.pages,
+		docs_dir,
+		upload_local=upload_local if upload_images else None,
+	)
+	tags = extract_tags(meta)
+	_ = title_conv
+
+	if dry_run:
+		log.info(
+			"dry-run %s content=%d chars images=%d tags=%s",
+			item.file_rel,
+			len(content),
+			len(image_paths),
+			tags,
+		)
+		return "dry-run"
+
+	page_id = state.pages[item.file_rel]["id"]
+	update_page_markdown(token, page_id, content)
+	applied_tags: list[str] = []
+	try:
+		applied_tags = update_page_tags(
+			token,
+			page_id,
+			tags,
+			property_name=tags_property,
+			tags_cache=tags_cache,
+		)
+	except urllib.error.HTTPError as exc:
+		body = getattr(exc, "reason", "") or ""
+		log.warning("tags update failed for %s: %s %s", item.file_rel, exc.code, body)
+	except RuntimeError as exc:
+		log.warning("tags update failed for %s: %s", item.file_rel, exc)
+	attached = 0
+	if upload_images and image_paths:
+		attached = attach_placeholder_images(token, page_id, image_paths)
+	if set(applied_tags) == set(tags):
+		tags_display: Any = applied_tags or "—"
+	else:
+		tags_display = f"FAILED wanted={tags} applied={applied_tags}"
+	log.info(
+		"ok %s (%s, images=%d/%d, tags=%s)",
+		item.file_rel,
+		"created" if created else "updated",
+		attached,
+		len(image_paths),
+		tags_display,
+	)
+	time.sleep(delay)
+	return "created" if created else "updated"
+
+
+def collect_targets(
+	*,
+	full: bool,
+	diff: DiffSet,
+	nav_index: dict[str, NavItem],
+	docs_dir: Path,
+	sections: list[str] | None,
+) -> tuple[list[NavItem], set[str]]:
+	"""Return ``(pages to sync, deleted rel paths)``."""
+	deleted = {
+		p
+		for p in diff.md_deleted
+		if filter_sections(p, sections) and not is_index_doc(p)
+	}
+
+	def _include(rel: str) -> bool:
+		if is_index_doc(rel):
+			return False
+		return filter_sections(rel, sections)
+
+	if full:
+		items = [
+			item
+			for item in nav_index.values()
+			if item.file_rel
+			and _include(item.file_rel)
+			and (docs_dir / item.file_rel).exists()
+		]
+		return items, deleted
+
+	wanted = set(diff.md_changed)
+	if diff.assets_changed:
+		wanted |= expand_asset_dependents(
+			diff.assets_changed, nav_index, docs_dir, sections
+		)
+
+	items: list[NavItem] = []
+	for rel in sorted(wanted):
+		if is_index_doc(rel):
+			log.info("skip index.md: %s", rel)
+			continue
+		if not filter_sections(rel, sections):
+			continue
+		item = nav_index.get(rel)
+		if item is None or not item.file_rel:
+			log.warning("changed file not in nav, skip: %s", rel)
+			continue
+		items.append(item)
+	return items, deleted
+
+
+def run_sync(options: SyncOptions) -> int:
+	"""Main sync entry used by the CLI. Returns a process exit code."""
+	options = _apply_env_overrides(options)
+	if options.verbose:
+		setup_logging(True)
+
+	token = resolve_token(
+		options.token,
+		options.project_root,
+		allow_cursor_mcp_token=options.allow_cursor_mcp_token,
+		silence_mcp_token_warning=options.silence_mcp_token_warning,
+	)
+	if not token and not options.dry_run:
+		log.error(
+			"Notion token not found. Set NOTION_TOKEN, add a project .env / "
+			".notion_token, or enable allow_cursor_mcp_token for developer use."
+		)
+		return 1
+
+	if not options.database_id or not options.data_source_id:
+		log.error(
+			"database_id and data_source_id are required "
+			"(mkdocs.yml notion_sync or NOTION_WIKI_DATABASE / "
+			"NOTION_WIKI_DATA_SOURCE)."
+		)
+		return 1
+
+	state_path = options.state_path
+	sections = options.section
+	docs_prefix = _docs_prefix(options.project_root, options.docs_dir)
+
+	# Resolve what to sync.
+	path_list: list[str] = []
+	if options.paths:
+		path_list.extend(options.paths)
+	if options.paths_file is not None:
+		raw = Path(options.paths_file).read_text(encoding="utf-8")
+		path_list.extend(line.strip() for line in raw.splitlines() if line.strip())
+
+	if path_list:
+		normalized: set[str] = set()
+		for p in path_list:
+			normalized.add(_strip_docs_prefix(p, docs_prefix))
+		diff = DiffSet(md_changed=normalized)
+		base: str | None = "(paths)"
+		full = False
+	elif options.full:
+		diff = DiffSet(nav_changed=True)
+		base = None
+		full = True
+	else:
+		base = resolve_git_base(options.project_root, options.base)
+		full = base is None
+		if full:
+			log.info("no git base available → full sync")
+			diff = DiffSet(nav_changed=True)
+		else:
+			log.info("incremental sync since %s", base)
+			diff = git_diff(base, options.project_root, options.docs_dir)
+
+	log.info(
+		"diff: md=%d deleted=%d assets=%d nav_changed=%s full=%s",
+		len(diff.md_changed),
+		len(diff.md_deleted),
+		len(diff.assets_changed),
+		diff.nav_changed,
+		full,
+	)
+
+	tree, tree_source = build_page_tree(
+		nav_file=options.nav_file,
+		notes_root=options.notes_root,
+		docs_dir=options.docs_dir,
+	)
+	log.info("page tree source: %s", tree_source)
+	nav_index = index_tree(tree)
+
+	# Load / rebuild page map.
+	state = load_state(state_path, default_title=options.title_property)
+	need_rebuild = options.rebuild_state or not state.pages
+	if need_rebuild:
+		if options.dry_run and not token:
+			log.warning("dry-run without token: empty state")
+		else:
+			assert token
+			log.info("rebuilding page map from Notion wiki…")
+			state = rebuild_state_from_wiki(
+				token,
+				data_source_id=options.data_source_id,
+				database_id=options.database_id,
+				title_property=options.title_property,
+				tree=tree,
+				sections=sections,
+			)
+			if not options.dry_run:
+				save_state(state_path, state)
+			log.info("mapped %d keys", len(state.pages))
+	else:
+		state.root_page_id = state.root_page_id or options.database_id
+		state.data_source_id = state.data_source_id or options.data_source_id
+		state.title_property = state.title_property or options.title_property
+
+	targets, deleted = collect_targets(
+		full=full,
+		diff=diff,
+		nav_index=nav_index,
+		docs_dir=options.docs_dir,
+		sections=sections,
+	)
+
+	if deleted:
+		for rel in sorted(deleted):
+			log.info("deleted locally (Notion page left intact): %s", rel)
+
+	if not targets:
+		log.info("nothing to sync")
+		return 0
+
+	tags_cache: TagsSchemaCache | None = None
+	if not options.dry_run and token:
+		tags_cache = TagsSchemaCache(
+			data_source_id=state.data_source_id or options.data_source_id,
+			property_name=options.tags_property,
+		)
+
+	log.info("syncing %d page(s)", len(targets))
+	stats = {"created": 0, "updated": 0, "dry-run": 0, "missing": 0, "failed": 0}
+	for item in targets:
+		try:
+			result = sync_one_page(
+				token or "",
+				state,
+				state_path,
+				nav_index,
+				item,
+				docs_dir=options.docs_dir,
+				site_url=options.site_url,
+				delay=options.delay,
+				dry_run=options.dry_run,
+				upload_images=not options.no_images,
+				tags_property=options.tags_property,
+				tags_cache=tags_cache,
+			)
+			stats[result] = stats.get(result, 0) + 1
+		except urllib.error.HTTPError as exc:
+			body = getattr(exc, "reason", "") or ""
+			log.error("FAIL %s: %s %s", item.file_rel, exc.code, body)
+			stats["failed"] += 1
+			if not options.continue_on_error:
+				return 1
+		except Exception as exc:  # noqa: BLE001 - per-page catch-all for continue_on_error
+			log.error("FAIL %s: %s", item.file_rel, exc)
+			stats["failed"] += 1
+			if not options.continue_on_error:
+				return 1
+
+	if not options.dry_run:
+		save_state(state_path, state)
+	log.info("done %s", json.dumps(stats, ensure_ascii=False))
+	return 1 if stats["failed"] else 0

--- a/src/mkdocs_note/utils/scanner.py
+++ b/src/mkdocs_note/utils/scanner.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 
-from mkdocs.structure.files import File, Files
 from mkdocs.plugins import get_plugin_logger
+from mkdocs.structure.files import File, Files
 
 from mkdocs_note.utils.meta import validate_frontmatter
-
 
 logger = get_plugin_logger(__name__)
 
@@ -54,6 +53,6 @@ def scan_notes(files: Files, config) -> tuple[list[File], list[File]]:
 				invalid_files.append(f)
 	except Exception as e:
 		logger.error(f"Error scanning notes: {e}")
-		raise e
+		raise
 
 	return notes, invalid_files

--- a/src/mkdocs_note/utils/tree.py
+++ b/src/mkdocs_note/utils/tree.py
@@ -1,0 +1,234 @@
+"""Hierarchical page-tree helpers shared by CLI tools and Notion sync.
+
+Produces a uniform ``TreeNode`` shape from either ``.nav.yml`` (awesome-nav)
+or a filesystem walk under ``notes_root`` (directory hierarchy preserved).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+from mkdocs.plugins import get_plugin_logger
+
+logger = get_plugin_logger(__name__)
+
+CONTENT_SUFFIXES = {".md", ".ipynb"}
+
+
+@dataclass
+class TreeNode:
+	"""A navigation / filesystem tree node.
+
+	Leaf content pages set ``file_rel``; intermediate sections leave it ``None``.
+	"""
+
+	key: str
+	title: str
+	file_rel: str | None
+	parent_key: str
+	children: list[TreeNode] = field(default_factory=list)
+
+
+def docs_rel(path: str) -> str:
+	"""Normalize path separators to forward slashes."""
+	return path.replace("\\", "/")
+
+
+def title_from_path(path: Path) -> str:
+	"""Default title from a file stem."""
+	return path.stem
+
+
+def is_index_doc(rel: str) -> bool:
+	"""True for any docs-relative path whose basename is ``index.md``."""
+	return Path(rel).name.lower() == "index.md"
+
+
+def resolve_doc_path(raw: str, docs_prefix: str = "docs/") -> str:
+	"""Strip optional docs prefix and quotes from a nav path entry."""
+	raw = raw.strip().strip('"').strip("'")
+	prefix = docs_prefix if docs_prefix.endswith("/") else f"{docs_prefix}/"
+	# Also accept bare "docs/" when docs_dir is custom.
+	if raw.startswith("docs/"):
+		raw = raw[5:]
+	elif prefix != "docs/" and raw.startswith(prefix):
+		raw = raw[len(prefix) :]
+	return docs_rel(raw)
+
+
+def walk_tree(items: list[TreeNode]) -> list[TreeNode]:
+	"""Depth-first flatten of a tree."""
+	ordered: list[TreeNode] = []
+	for item in items:
+		ordered.append(item)
+		ordered.extend(walk_tree(item.children))
+	return ordered
+
+
+def index_tree(tree: list[TreeNode]) -> dict[str, TreeNode]:
+	"""Map node key → node for the entire tree."""
+	return {item.key: item for item in walk_tree(tree)}
+
+
+def load_nav_yaml(nav_path: Path) -> list[Any]:
+	"""Load the ``nav`` list from an awesome-nav ``.nav.yml`` file."""
+	with nav_path.open("r", encoding="utf-8") as f:
+		data = yaml.safe_load(f) or {}
+	if isinstance(data, dict):
+		return data.get("nav", data) if isinstance(data.get("nav", data), list) else []
+	if isinstance(data, list):
+		return data
+	return []
+
+
+def build_nav_tree(
+	nodes: list[Any],
+	parent_key: str = "",
+	*,
+	docs_prefix: str = "docs/",
+) -> list[TreeNode]:
+	"""Build a ``TreeNode`` forest from awesome-nav YAML nodes."""
+	items: list[TreeNode] = []
+	for node in nodes:
+		if isinstance(node, str):
+			rel = resolve_doc_path(node, docs_prefix=docs_prefix)
+			items.append(
+				TreeNode(
+					key=rel,
+					title=title_from_path(Path(rel)),
+					file_rel=rel,
+					parent_key=parent_key,
+				)
+			)
+			continue
+		if not isinstance(node, dict):
+			continue
+		for title, child in node.items():
+			title_s = str(title)
+			if isinstance(child, str):
+				rel = resolve_doc_path(child, docs_prefix=docs_prefix)
+				items.append(
+					TreeNode(
+						key=rel,
+						title=title_s,
+						file_rel=rel,
+						parent_key=parent_key,
+					)
+				)
+			elif isinstance(child, list):
+				section_key = f"{parent_key}/{title_s}" if parent_key else title_s
+				section = TreeNode(
+					key=section_key,
+					title=title_s,
+					file_rel=None,
+					parent_key=parent_key,
+					children=build_nav_tree(
+						child, section_key, docs_prefix=docs_prefix
+					),
+				)
+				items.append(section)
+	return items
+
+
+def build_directory_tree(
+	root: Path,
+	*,
+	parent_key: str = "",
+	rel_prefix: str = "",
+) -> list[TreeNode]:
+	"""Build a ``TreeNode`` forest from filesystem hierarchy under ``root``.
+
+	Directories become sections; ``.md`` / ``.ipynb`` leaves become content pages.
+	``index.md`` files are omitted from the tree (callers still skip them on sync).
+
+	Args:
+	    root: Absolute or relative notes root directory.
+	    parent_key: Parent nav key for this level.
+	    rel_prefix: Docs-relative path prefix for children.
+
+	Returns:
+	    Ordered list of tree nodes for this directory level.
+	"""
+	root = Path(root)
+	if not root.is_dir():
+		return []
+
+	items: list[TreeNode] = []
+	# Stable ordering: directories first (alpha), then files (alpha).
+	entries = sorted(root.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower()))
+	for entry in entries:
+		if entry.name.startswith("."):
+			continue
+		if entry.is_dir():
+			# Skip co-located asset directories.
+			if entry.name == "assets":
+				continue
+			rel = docs_rel(f"{rel_prefix}/{entry.name}" if rel_prefix else entry.name)
+			section_key = rel
+			children = build_directory_tree(
+				entry, parent_key=section_key, rel_prefix=rel
+			)
+			if not children:
+				continue
+			items.append(
+				TreeNode(
+					key=section_key,
+					title=entry.name,
+					file_rel=None,
+					parent_key=parent_key,
+					children=children,
+				)
+			)
+			continue
+
+		suffix = entry.suffix.lower()
+		if suffix not in CONTENT_SUFFIXES:
+			continue
+		rel = docs_rel(f"{rel_prefix}/{entry.name}" if rel_prefix else entry.name)
+		if is_index_doc(rel):
+			continue
+		items.append(
+			TreeNode(
+				key=rel,
+				title=title_from_path(entry),
+				file_rel=rel,
+				parent_key=parent_key,
+			)
+		)
+	return items
+
+
+def build_page_tree(
+	*,
+	nav_file: Path | None,
+	notes_root: Path,
+	docs_dir: Path,
+) -> tuple[list[TreeNode], str]:
+	"""Resolve page tree: prefer ``.nav.yml``, else ``notes_root`` directory scan.
+
+	Args:
+	    nav_file: Path to ``.nav.yml`` (may be None or missing).
+	    notes_root: Notes directory for filesystem fallback.
+	    docs_dir: Docs root used when stripping prefixes in nav paths.
+
+	Returns:
+	    Tuple of (tree, source_label) where source_label is ``"nav.yml"`` or
+	    ``"directory"``.
+	"""
+	docs_prefix = docs_rel(str(docs_dir)).rstrip("/") + "/"
+	if nav_file is not None and nav_file.is_file():
+		nodes = load_nav_yaml(nav_file)
+		return build_nav_tree(nodes, docs_prefix=docs_prefix), "nav.yml"
+
+	logger.warning(
+		"Navigation file not found (%s). Falling back to directory scan of "
+		"'%s' (directory hierarchy preserved). For custom titles and grouping "
+		"that match your site nav, install mkdocs-awesome-nav and add a "
+		".nav.yml under your docs directory.",
+		nav_file,
+		notes_root,
+	)
+	return build_directory_tree(notes_root), "directory"

--- a/tests/smoke_test.py
+++ b/tests/smoke_test.py
@@ -55,9 +55,9 @@ def test_core_modules():
 	# Test utils.meta module
 	try:
 		from mkdocs_note.utils.meta import (
-			validate_frontmatter,
 			extract_date,
 			extract_title,
+			validate_frontmatter,
 		)
 
 		assert validate_frontmatter is not None

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -5,19 +5,19 @@ This module tests all CLI command classes: NewCommand, RemoveCommand,
 MoveCommand, and CleanCommand.
 """
 
-import unittest
-from pathlib import Path
-import tempfile
 import shutil
-from datetime import datetime
+import tempfile
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
 
+from mkdocs_note.utils.cli import common
 from mkdocs_note.utils.cli.commands import (
+	CleanCommand,
+	MoveCommand,
 	NewCommand,
 	RemoveCommand,
-	MoveCommand,
-	CleanCommand,
 )
-from mkdocs_note.utils.cli import common
 
 
 class TestNewCommand(unittest.TestCase):
@@ -109,7 +109,7 @@ class TestNewCommand(unittest.TestCase):
 				date_str = line.split("date:", 1)[1].strip()
 				# Verify date can be parsed
 				try:
-					datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S")
+					datetime.strptime(date_str, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC)
 					parsed = True
 				except ValueError:
 					parsed = False

--- a/tests/test_cli_common.py
+++ b/tests/test_cli_common.py
@@ -4,18 +4,18 @@ Test suite for mkdocs_note.utils.cli.common module.
 This module tests the common utility functions used by CLI commands.
 """
 
+import shutil
+import tempfile
 import unittest
 from pathlib import Path
-import tempfile
-import shutil
 
 from mkdocs_note.utils.cli.common import (
+	cleanup_empty_directories,
+	ensure_parent_directory,
 	get_asset_directory,
 	get_asset_directory_by_permalink,
 	get_permalink_from_file,
 	is_excluded_name,
-	ensure_parent_directory,
-	cleanup_empty_directories,
 )
 
 

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -5,10 +5,11 @@ This module tests the complete CLI workflow including command parsing
 and execution through the Click interface.
 """
 
-import unittest
-import tempfile
 import shutil
+import tempfile
+import unittest
 from pathlib import Path
+
 from click.testing import CliRunner
 
 from mkdocs_note.cli import cli

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,6 @@
-import unittest
-import sys
 import os
+import sys
+import unittest
 
 # Add src to path to allow imports
 sys.path.insert(
@@ -42,6 +42,7 @@ class TestMkdocsNoteConfig(unittest.TestCase):
 			"notes_root",
 			"recent_notes_config",
 			"graph_config",
+			"notion_sync",
 		]
 
 		for attr in required_attrs:
@@ -69,6 +70,18 @@ class TestMkdocsNoteConfig(unittest.TestCase):
 				self.config.graph_config,
 				f"graph_config missing required key: {key}",
 			)
+
+	def test_notion_sync_defaults(self):
+		"""Test Notion sync configuration defaults."""
+		ns = self.config.notion_sync
+		self.assertEqual(ns["docs_dir"], "docs")
+		self.assertEqual(ns["nav_file"], "docs/.nav.yml")
+		self.assertEqual(ns["database_id"], "")
+		self.assertEqual(ns["data_source_id"], "")
+		self.assertEqual(ns["title_property"], "页面")
+		self.assertEqual(ns["tags_property"], "标签")
+		self.assertFalse(ns["allow_cursor_mcp_token"])
+		self.assertFalse(ns["silence_mcp_token_warning"])
 
 
 if __name__ == "__main__":

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,5 +1,6 @@
-import unittest
 import re
+import unittest
+
 from click.testing import CliRunner
 
 from mkdocs_note.cli import cli
@@ -27,13 +28,13 @@ class TestHelpOptions(unittest.TestCase):
 
 	def test_help_long_option(self):
 		"""Test that --help option works without errors."""
-		stdout, stderr, returncode = self.run_cli_command(["--help"])
+		stdout, _stderr, returncode = self.run_cli_command(["--help"])
 
 		# Should not throw error
 		self.assertEqual(
 			returncode,
 			0,
-			f"--help failed with return code {returncode}. stderr: {stderr}",
+			f"--help failed with return code {returncode}. stderr: {_stderr}",
 		)
 
 		# Should contain help text
@@ -42,11 +43,13 @@ class TestHelpOptions(unittest.TestCase):
 
 	def test_help_short_option(self):
 		"""Test that -h option works without errors."""
-		stdout, stderr, returncode = self.run_cli_command(["-h"])
+		stdout, _stderr, returncode = self.run_cli_command(["-h"])
 
 		# Should not throw error
 		self.assertEqual(
-			returncode, 0, f"-h failed with return code {returncode}. stderr: {stderr}"
+			returncode,
+			0,
+			f"-h failed with return code {returncode}. stderr: {_stderr}",
 		)
 
 		# Should contain help text
@@ -55,8 +58,8 @@ class TestHelpOptions(unittest.TestCase):
 
 	def test_help_options_equal(self):
 		"""Test that --help and -h produce the same output."""
-		stdout_long, stderr_long, _ = self.run_cli_command(["--help"])
-		stdout_short, stderr_short, _ = self.run_cli_command(["-h"])
+		stdout_long, _stderr_long, _ = self.run_cli_command(["--help"])
+		stdout_short, _stderr_short, _ = self.run_cli_command(["-h"])
 
 		# Both should produce the same output
 		self.assertEqual(
@@ -65,13 +68,13 @@ class TestHelpOptions(unittest.TestCase):
 
 	def test_version_option(self):
 		"""Test that --version option works."""
-		stdout, stderr, returncode = self.run_cli_command(["--version"])
+		stdout, _stderr, returncode = self.run_cli_command(["--version"])
 
 		# Should not throw error
 		self.assertEqual(
 			returncode,
 			0,
-			f"--version failed with return code {returncode}. stderr: {stderr}",
+			f"--version failed with return code {returncode}. stderr: {_stderr}",
 		)
 
 		# Should contain version information
@@ -86,11 +89,11 @@ class TestHelpOptions(unittest.TestCase):
 	def test_help_with_subcommand(self):
 		"""Test that help works with subcommands."""
 		# Test with 'new' command
-		stdout, stderr, returncode = self.run_cli_command(["new", "--help"])
+		stdout, _stderr, returncode = self.run_cli_command(["new", "--help"])
 		self.assertEqual(
 			returncode,
 			0,
-			f"new --help failed with return code {returncode}. stderr: {stderr}",
+			f"new --help failed with return code {returncode}. stderr: {_stderr}",
 		)
 		self.assertIn("Create a new note", stdout)
 
@@ -114,7 +117,7 @@ class TestHelpOptions(unittest.TestCase):
 
 		for cmd in commands:
 			with self.subTest(command=cmd):
-				stdout, stderr, returncode = self.run_cli_command([cmd, "--help"])
+				stdout, _stderr, returncode = self.run_cli_command([cmd, "--help"])
 				self.assertEqual(
 					returncode,
 					0,

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,0 +1,57 @@
+"""Tests for shared frontmatter helpers."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(
+	0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from mkdocs_note.utils.meta import (
+	extract_tags,
+	parse_frontmatter,
+	parse_frontmatter_file,
+)
+
+
+class TestParseFrontmatter(unittest.TestCase):
+	def test_no_frontmatter(self):
+		meta, body = parse_frontmatter("# Hello\n\nworld")
+		self.assertEqual(meta, {})
+		self.assertIn("Hello", body)
+
+	def test_with_frontmatter(self):
+		text = "---\ntitle: Test\ntags:\n  - a\n  - b\n---\n\n# Body\n"
+		meta, body = parse_frontmatter(text)
+		self.assertEqual(meta.get("title"), "Test")
+		self.assertEqual(meta.get("tags"), ["a", "b"])
+		self.assertTrue(body.lstrip().startswith("# Body"))
+
+	def test_parse_frontmatter_file(self):
+		with tempfile.TemporaryDirectory() as tmp:
+			path = Path(tmp) / "note.md"
+			path.write_text("---\ntitle: X\n---\n\ncontent\n", encoding="utf-8")
+			meta, body = parse_frontmatter_file(path)
+			self.assertEqual(meta["title"], "X")
+			self.assertIn("content", body)
+
+
+class TestExtractTags(unittest.TestCase):
+	def test_list(self):
+		self.assertEqual(extract_tags({"tags": ["a", "b"]}), ["a", "b"])
+
+	def test_string(self):
+		self.assertEqual(extract_tags({"tags": "a, b"}), ["a", "b"])
+
+	def test_tag_alias(self):
+		self.assertEqual(extract_tags({"tag": "solo"}), ["solo"])
+
+	def test_empty(self):
+		self.assertEqual(extract_tags({}), [])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_notion_convert.py
+++ b/tests/test_notion_convert.py
@@ -1,0 +1,75 @@
+"""Tests for Notion markdown conversion."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(
+	0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from mkdocs_note.utils.notion.convert import (
+	convert_admonitions_and_tabs,
+	convert_inline_math,
+	convert_markdown_file,
+	is_gfm_table_separator_row,
+	strip_gfm_table_separators,
+)
+
+
+class TestAdmonitions(unittest.TestCase):
+	def test_note_callout(self):
+		src = '!!! note "Title"\n    body line\n'
+		out = convert_admonitions_and_tabs(src)
+		self.assertIn("<callout", out)
+		self.assertIn("Title", out)
+		self.assertIn("body line", out)
+
+	def test_collapse_details(self):
+		src = "??? tip\n    hidden\n"
+		out = convert_admonitions_and_tabs(src)
+		self.assertIn("<details>", out)
+		self.assertIn("hidden", out)
+
+	def test_tabs_to_heading(self):
+		src = '=== "Tab A"\n    content\n'
+		out = convert_admonitions_and_tabs(src)
+		self.assertIn("### Tab A", out)
+		self.assertIn("content", out)
+
+
+class TestMathAndTables(unittest.TestCase):
+	def test_inline_math(self):
+		out = convert_inline_math("value $x+1$ here")
+		self.assertIn("$`x+1`$", out)
+
+	def test_table_separator(self):
+		self.assertTrue(is_gfm_table_separator_row("| --- | :---: |"))
+		text = "| a | b |\n| --- | --- |\n| 1 | 2 |\n"
+		stripped = strip_gfm_table_separators(text)
+		self.assertNotIn("---", stripped)
+		self.assertIn("| 1 | 2 |", stripped)
+
+
+class TestConvertFile(unittest.TestCase):
+	def test_markdown_file(self):
+		with tempfile.TemporaryDirectory() as tmp:
+			root = Path(tmp)
+			path = root / "note.md"
+			path.write_text(
+				"---\ntitle: Hello\ntags: [t1]\n---\n\n# Hello\n\n!!! note\n    hi\n",
+				encoding="utf-8",
+			)
+			title, body, meta = convert_markdown_file(
+				path, site_url="https://example.com", page_map={}, docs_root=root
+			)
+			self.assertEqual(title, "Hello")
+			self.assertIn("<callout", body)
+			self.assertNotIn("# Hello", body.split("\n")[0] if body else "")
+			self.assertEqual(meta.get("tags"), ["t1"])
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,15 +1,17 @@
-import unittest
-import sys
 import os
-from unittest.mock import Mock, MagicMock, patch
+import sys
+import unittest
+from unittest.mock import MagicMock, Mock, patch
 
 # Add src to path to allow imports
 sys.path.insert(
 	0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
 )
 
-from mkdocs_note.plugin import MkdocsNotePlugin
+from datetime import UTC
+
 from mkdocs_note.config import MkdocsNoteConfig
+from mkdocs_note.plugin import MkdocsNotePlugin
 
 
 class TestMkdocsNotePlugin(unittest.TestCase):
@@ -41,8 +43,8 @@ class TestMkdocsNotePlugin(unittest.TestCase):
 
 	def test_is_note_index_page(self):
 		"""Test is_note_index_page method."""
-		import tempfile
 		import os
+		import tempfile
 
 		# Create a temporary directory structure
 		with tempfile.TemporaryDirectory() as temp_dir:
@@ -179,8 +181,9 @@ class TestMkdocsNotePlugin(unittest.TestCase):
 
 	def test_insert_recent_note_links(self):
 		"""Test insert_recent_note_links function."""
-		from mkdocs_note.plugin import insert_recent_note_links
 		from datetime import datetime
+
+		from mkdocs_note.plugin import insert_recent_note_links
 
 		# Create mock files
 		mock_file1 = Mock()
@@ -188,13 +191,13 @@ class TestMkdocsNotePlugin(unittest.TestCase):
 		mock_file1.page = Mock()
 		mock_file1.page.abs_url = "/note1/"
 		mock_file1.note_title = "Note 1"
-		mock_file1.note_date = datetime.now()
+		mock_file1.note_date = datetime.now(UTC)
 
 		mock_file2 = Mock()
 		mock_file2.page = Mock()
 		mock_file2.page.abs_url = "/note2/"
 		mock_file2.note_title = "Note 2"
-		mock_file2.note_date = datetime.now()
+		mock_file2.note_date = datetime.now(UTC)
 
 		notes_list = [mock_file1, mock_file2]
 		markdown = "# Index\n<!-- recent_notes -->"

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -1,0 +1,76 @@
+"""Tests for page-tree helpers (nav.yml + directory scan)."""
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(
+	0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
+
+from mkdocs_note.utils.tree import (
+	build_directory_tree,
+	build_nav_tree,
+	build_page_tree,
+	index_tree,
+	is_index_doc,
+)
+
+
+class TestNavTree(unittest.TestCase):
+	def test_build_nav_tree(self):
+		nodes = [
+			"index.md",
+			{"Getting Started": "getting-started.md"},
+			{"Guide": [{"Install": "usage/install.md"}]},
+		]
+		tree = build_nav_tree(nodes)
+		index = index_tree(tree)
+		self.assertIn("getting-started.md", index)
+		self.assertEqual(index["getting-started.md"].title, "Getting Started")
+		self.assertIn("Guide", index)
+		self.assertIsNone(index["Guide"].file_rel)
+		self.assertIn("usage/install.md", index)
+		self.assertEqual(index["usage/install.md"].parent_key, "Guide")
+
+	def test_is_index_doc(self):
+		self.assertTrue(is_index_doc("usage/index.md"))
+		self.assertFalse(is_index_doc("usage/cli.md"))
+
+
+class TestDirectoryTree(unittest.TestCase):
+	def test_preserves_hierarchy(self):
+		with tempfile.TemporaryDirectory() as tmp:
+			root = Path(tmp)
+			(root / "a.md").write_text("# A\n", encoding="utf-8")
+			(root / "sub").mkdir()
+			(root / "sub" / "b.md").write_text("# B\n", encoding="utf-8")
+			(root / "sub" / "index.md").write_text("# Idx\n", encoding="utf-8")
+			(root / "assets").mkdir()
+			(root / "assets" / "x.png").write_text("x", encoding="utf-8")
+
+			tree = build_directory_tree(root)
+			index = index_tree(tree)
+			self.assertIn("a.md", index)
+			self.assertIn("sub", index)
+			self.assertIn("sub/b.md", index)
+			self.assertNotIn("sub/index.md", index)
+			self.assertEqual(index["sub/b.md"].parent_key, "sub")
+
+	def test_build_page_tree_fallback(self):
+		with tempfile.TemporaryDirectory() as tmp:
+			root = Path(tmp)
+			(root / "note.md").write_text("# N\n", encoding="utf-8")
+			tree, source = build_page_tree(
+				nav_file=root / "missing.nav.yml",
+				notes_root=root,
+				docs_dir=root,
+			)
+			self.assertEqual(source, "directory")
+			self.assertTrue(any(n.file_rel == "note.md" for n in tree))
+
+
+if __name__ == "__main__":
+	unittest.main()

--- a/uv.lock
+++ b/uv.lock
@@ -104,7 +104,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -938,7 +938,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-note"
-version = "3.1.2"
+version = "3.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "colorlog" },


### PR DESCRIPTION
- Notion wiki sync via CLI: `mkdocs-note notion-sync` / `ns` (git-diff incremental by default).

- Plugin config `notion_sync` for docs/nav paths, wiki IDs, tags/title properties, and delay.

- Shared helpers: path-level frontmatter / tags in `utils.meta`, hierarchical page tree in `utils.tree`.

- Notion package: `utils.notion.convert`, `utils.notion.client`, `utils.notion.sync`.